### PR TITLE
fix(guides): Update Spec File Guide for 0.34

### DIFF
--- a/default/pages/guides/uploading-spec.hbs
+++ b/default/pages/guides/uploading-spec.hbs
@@ -1,29 +1,48 @@
 {{#> layout pageTitle="Dev Portal - Uploading Spec File" }}
 
-  {{#* inline "content-block"}}
-    <div class="app-container">
-      <div class="container">
-        {{> guides/sidebar}}
+{{#* inline "content-block"}}
+<div class="app-container">
+  <div class="container">
+     {{> guides/sidebar}}
         <section class="page-wrapper kong-doc">
-				<h1>Uploading your Specification File</h1>
-				<ol>
-					<li>Find your specification file, if you don't have one handy we can use the Swagger Pet Store Example: 
-						<a href="http://petstore.swagger.io/v2/swagger.json">Download File</a>
-					</li>
-					<li>Upload the specification with the following call from your terminal: <code>[POST swagger.json -type page]</code></li>
-					<li>Refresh the browser and the new specification file should be at the end of the list:<br/><img src="data:image/svg+xml,%3Csvg%20width%3D%22810%22%20height%3D%22132%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%3E%3Cdefs%3E%3Cpath%20id%3D%22b%22%20d%3D%22M0%200h808v64H0z%22/%3E%3Cfilter%20x%3D%22-.2%25%22%20y%3D%22-4.7%25%22%20width%3D%22100.5%25%22%20height%3D%22107.8%25%22%20filterUnits%3D%22objectBoundingBox%22%20id%3D%22a%22%3E%3CfeOffset%20dy%3D%221%22%20in%3D%22SourceAlpha%22%20result%3D%22shadowOffsetOuter1%22/%3E%3CfeColorMatrix%20values%3D%220%200%200%200%200.901960784%200%200%200%200%200.901960784%200%200%200%200%200.901960784%200%200%200%201%200%22%20in%3D%22shadowOffsetOuter1%22%20result%3D%22shadowMatrixOuter1%22/%3E%3CfeOffset%20dy%3D%22-1%22%20in%3D%22SourceAlpha%22%20result%3D%22shadowOffsetOuter2%22/%3E%3CfeGaussianBlur%20stdDeviation%3D%22.5%22%20in%3D%22shadowOffsetOuter2%22%20result%3D%22shadowBlurOuter2%22/%3E%3CfeColorMatrix%20values%3D%220%200%200%200%200.901960784%200%200%200%200%200.901960784%200%200%200%200%200.901960784%200%200%200%201%200%22%20in%3D%22shadowBlurOuter2%22%20result%3D%22shadowMatrixOuter2%22/%3E%3CfeMerge%3E%3CfeMergeNode%20in%3D%22shadowMatrixOuter1%22/%3E%3CfeMergeNode%20in%3D%22shadowMatrixOuter2%22/%3E%3C/feMerge%3E%3C/filter%3E%3Cpath%20id%3D%22d%22%20d%3D%22M0%200h808v64H0z%22/%3E%3Cfilter%20x%3D%22-.1%25%22%20y%3D%22-.8%25%22%20width%3D%22100.1%25%22%20height%3D%22103.1%25%22%20filterUnits%3D%22objectBoundingBox%22%20id%3D%22c%22%3E%3CfeOffset%20dy%3D%221%22%20in%3D%22SourceAlpha%22%20result%3D%22shadowOffsetOuter1%22/%3E%3CfeColorMatrix%20values%3D%220%200%200%200%200.901960784%200%200%200%200%200.901960784%200%200%200%200%200.901960784%200%200%200%201%200%22%20in%3D%22shadowOffsetOuter1%22/%3E%3C/filter%3E%3C/defs%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%20transform%3D%22translate%281%202%29%22%3E%3Cuse%20fill%3D%22%23000%22%20filter%3D%22url%28%23a%29%22%20xlink%3Ahref%3D%22%23b%22/%3E%3Cuse%20fill%3D%22%23FFF%22%20xlink%3Ahref%3D%22%23b%22/%3E%3C/g%3E%3Ctext%20font-family%3D%22Roboto-Light%2C%20Roboto%22%20font-size%3D%2215%22%20fill%3D%22%23000%22%20fill-opacity%3D%22.45%22%20transform%3D%22translate%281%202%29%22%3E%3Ctspan%20x%3D%22197%22%20y%3D%2237%22%3Especification%3C/tspan%3E%3C/text%3E%3Ctext%20font-family%3D%22Roboto-Light%2C%20Roboto%22%20font-size%3D%2215%22%20fill%3D%22%23000%22%20fill-opacity%3D%22.45%22%20transform%3D%22translate%281%202%29%22%3E%3Ctspan%20x%3D%22331%22%20y%3D%2237%22%3E02/15/2018%20-%2014%3A56%3A05%3C/tspan%3E%3C/text%3E%3Ctext%20font-family%3D%22Roboto-Light%2C%20Roboto%22%20font-size%3D%2215%22%20fill%3D%22%23000%22%20fill-opacity%3D%22.85%22%20transform%3D%22translate%281%202%29%22%3E%3Ctspan%20x%3D%2216%22%20y%3D%2237%22%3Espec2.yaml%3C/tspan%3E%3C/text%3E%3Cg%3E%3Cg%20transform%3D%22translate%281%2067%29%22%3E%3Cuse%20fill%3D%22%23000%22%20filter%3D%22url%28%23c%29%22%20xlink%3Ahref%3D%22%23d%22/%3E%3Cuse%20fill%3D%22%23F2FAFF%22%20xlink%3Ahref%3D%22%23d%22/%3E%3C/g%3E%3Ctext%20font-family%3D%22Roboto-Light%2C%20Roboto%22%20font-size%3D%2215%22%20fill%3D%22%23000%22%20fill-opacity%3D%22.45%22%20transform%3D%22translate%281%2067%29%22%3E%3Ctspan%20x%3D%22197%22%20y%3D%2237%22%3Especification%3C/tspan%3E%3C/text%3E%3Ctext%20font-family%3D%22Roboto-Light%2C%20Roboto%22%20font-size%3D%2215%22%20fill%3D%22%23000%22%20fill-opacity%3D%22.45%22%20transform%3D%22translate%281%2067%29%22%3E%3Ctspan%20x%3D%22331%22%20y%3D%2237%22%3E02/15/2018%20-%2014%3A56%3A05%3C/tspan%3E%3C/text%3E%3Ctext%20font-family%3D%22Roboto-Light%2C%20Roboto%22%20font-size%3D%2215%22%20fill%3D%22%23000%22%20fill-opacity%3D%22.85%22%20transform%3D%22translate%281%2067%29%22%3E%3Ctspan%20x%3D%2216%22%20y%3D%2237%22%3Eswagger.json%3C/tspan%3E%3C/text%3E%3C/g%3E%3C/g%3E%3C/svg%3E"/></li>
-					<li>Now we need to generate the new documentation, in order to do that we need to tell the documentation partial (<code>rendered-spec1.hbs</code>) the name of our new spec: GET the <code>rendered-spec1.hbs</code> file and find the following part: 
-						{{{{raw}}}}
-							<code>{{> spec-renderer spec=vitals"}}</code>
-						{{{{/raw}}}}
-					</li>
-					<li>Change <code>vitals</code> for <code>swagger</code> and POST it back to Kong: <code>[POST rendered-spec.hbs -type partial]</code></li>
-					<li>Lastly, open the Dev Portal and navigation to API 1 or click "Open Page" in the <code>api1.hbs</code> table row, and that's it.</li>
-				</ol>
-				<p>Well done, pat yourself on the back</p> 
-			</div>
-		</div>
-	</div>
-	{{/inline}}
+{{#markdown}}
 
+# Uploading a Specification file
+
+## Option 1 - The Terminal
+
+- Upload a Specification file with the following call in the terminal
+	- In this example we are using the 
+	[Swagger Petstore](http://petstore.swagger.io/v2/swagger.json)
+
+```bash
+	curl -X POST http://127.0.0.1:8001/WORKSPACE_NAME/files \
+	curl -X POST http://127.0.0.1:8001/WORKSPACE_NAME/files \
+	-F "type=spec" \
+	-F "name=swagger" \
+	-F "contents=@swagger.json" \
+	-F "auth=true"
+```
+
+- Navigate to the Dev Portal [API Catalog](/documentation), the new Swagger Spec
+should now be listed.
+
+## Option 2 - The Kong Manager
+
+- In the Kong Manager, navigate to the Dev Portal 'Specs' page in your Workspace.
+- Click the button **_+ Add Spec_**
+- Enter `swagger` as the file name
+- Check the **_Requires Authentication_** Box
+- Click the **_Create File_** button
+- Copy and paste your spec file into the code editor.
+- Once finished, click the **_Update File_** button.
+- Back in the Dev Portal, navigate to the Dev Portal 
+[API Catalog](/documentation), the new Swagger Spec should now be listed.
+
+
+{{/markdown}}
+</section>
+</div>
+</div>
+{{/inline}}
 {{/layout}}


### PR DESCRIPTION
## Changelog
- Updates information for uploading a spec for 0.34 release
- Rewrites the file in Markdown
<img width="1039" alt="screen shot 2018-11-29 at 4 07 21 pm" src="https://user-images.githubusercontent.com/8921227/49260125-fef57580-f3f0-11e8-981a-a9774d6786e0.png">
