### PR TITLE
Imposed posix path to avoid push issues on Windows

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const {lstatSync, readdirSync, readFileSync, writeFileSync} = require('fs')
-const {join, parse} = require('path')
+const {join, parse} = require('path').posix
 const readline = require('readline')
 const https = require('https')
 const http = require('http')


### PR DESCRIPTION
The path plugin uses the platform specific separator when join path, this cause problems on windows, to avoid them I've forced the posix version of the path plugin that seems to make it work properly.