### PR TITLE
fix(index) remove duplicate specFiles computed

### DIFF
--- a/themes/default/partials/spec/index-vue.hbs
+++ b/themes/default/partials/spec/index-vue.hbs
@@ -144,12 +144,6 @@ window.registerApp(function () {
       }
     },
 
-    computed: {
-      specFiles () {
-        return this.fetchSpecs()
-      }
-    },
-
     watch: {
       filterModel: {
         handler: function() {
@@ -183,7 +177,7 @@ window.registerApp(function () {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  border-bottom: 1px solid #979797; 
+  border-bottom: 1px solid #979797;
   margin: 48px 148px;
   padding-bottom: 48px;
 }


### PR DESCRIPTION
This PR removes computed property `specFiles` as it is already defined in `data` and initialized in `mounted`. 

The duplicated var is causing an error in console:
![image](https://user-images.githubusercontent.com/5304468/56433716-ada62f80-6286-11e9-8e2d-c791f8a485b4.png)
