### PR TITLE
fix(base.css): add guides sidebar margin, port css to ie11

### DIFF
--- a/themes/default-ie11/partials/unauthenticated/assets/base/base-css.hbs
+++ b/themes/default-ie11/partials/unauthenticated/assets/base/base-css.hbs
@@ -301,10 +301,45 @@ section {
   flex-direction: column;
   text-align: center;
 }
+
 @media all and (max-width: 720px) {
   #ui-wrapper {
     margin-top: 40px;
   }
+}
+
+@media all and (min-width: 1200px) {
+  .kong-doc {
+    margin-left: 215px;
+  }
+  #ui-wrapper {
+    max-width: calc(100% - 215px) !important;
+    margin-left: 215px;
+  }
+}
+
+@media all and (max-width: 1200px) {
+  .kong-doc,
+  #ui-wrapper {
+    margin-left: 0;
+  }
+}
+
+.swagger-ui .description { 
+  word-wrap: break-word;
+}
+
+.swagger-ui .response-item {
+  word-break: break-word;
+}
+
+.swagger-ui .operations-container .opblock .response-code {
+  height: unset;
+  word-break: keep-all;
+}
+
+.swagger-ui .operations-container .opblock .response-code .markdown {
+  word-break: break-all;
 }
 
 /**************************************************************************

--- a/themes/default/partials/unauthenticated/assets/base/base-css.hbs
+++ b/themes/default/partials/unauthenticated/assets/base/base-css.hbs
@@ -311,6 +311,9 @@ section {
 }
 
 @media all and (min-width: 1200px) {
+  .kong-doc {
+    margin-left: 215px;
+  }
   #ui-wrapper {
     max-width: calc(100% - 215px) !important;
     margin-left: 215px;
@@ -318,6 +321,7 @@ section {
 }
 
 @media all and (max-width: 1200px) {
+  .kong-doc,
   #ui-wrapper {
     margin-left: 0;
   }
@@ -347,6 +351,11 @@ section {
 .swagger-ui .model-example-wrapper { overflow: auto; }
 .swagger-ui .code-block { background: hsla(220, 8%, 10%, 1); }
 .swagger-ui .operations-container select { border-color: rgba(255,255,255,0.1); }
+
+/**************************************************************************
+ * swagger-ui operation panel fixes
+ */
+.swagger-ui .code-block { max-height: 600px !important }
 
 .overlay {
   position: fixed;


### PR DESCRIPTION
- Copy swagger updates over to IE11 theme
- Update guides container with sidebar margin

Preview:

<img width="1531" alt="Screen Shot 2019-05-15 at 7 53 58 PM" src="https://user-images.githubusercontent.com/198276/57823137-4bd4ca80-774b-11e9-9007-3e4da9f636a5.png">
