### PR TITLE
fix(specs) remove duplicate computed specFiles var

### DIFF
--- a/themes/default-ie11/partials/spec/index-vue.hbs
+++ b/themes/default-ie11/partials/spec/index-vue.hbs
@@ -154,11 +154,6 @@ window.registerApp(function () {
         return tagStr;
       }
     },
-    computed: {
-      specFiles: function specFiles() {
-        return this.fetchSpecs();
-      }
-    },
     watch: {
       filterModel: {
         handler: function handler() {


### PR DESCRIPTION
This PR removes a duplicate var declaration `specFiles`. This fix has already been applied to default templates: https://github.com/Kong/kong-portal-templates/pull/26