### PR TITLE
fix(register) redirect to index after form submit when not auto approved

### DIFF
--- a/workspaces/default/portal.conf.yaml
+++ b/workspaces/default/portal.conf.yaml
@@ -6,3 +6,5 @@ redirect:
   unauthorized: unauthorized
   login: dashboard
   logout: ''
+  pending_approval: ''
+  pending_email_verification: ''

--- a/workspaces/default/themes/light-theme/partials/auth/forms/register/basic-auth.html
+++ b/workspaces/default/themes/light-theme/partials/auth/forms/register/basic-auth.html
@@ -58,10 +58,10 @@
           }).catch(onError)
         } else if (accountIsPendingEmailVerfication) {
           alert(accountIsPendingEmailVerificationMessage)
-          window.location.href = '';
+          window.location.href = Kong.Auth.getRedirectTo('{{portal.redirect.pending_email_verification}}');
         } else {
           alert(accountisPendingVerificationMessage)
-          window.location.href = '';
+          window.location.href = Kong.Auth.getRedirectTo('{{portal.redirect.pending_approval}}');
         }
       }
 

--- a/workspaces/default/themes/light-theme/partials/auth/forms/register/basic-auth.html
+++ b/workspaces/default/themes/light-theme/partials/auth/forms/register/basic-auth.html
@@ -33,7 +33,6 @@
       // Submission variables
       var baseApiUrl = window.Kong.getApiUrl();
       var authType = Kong.Auth.BASIC_AUTH;
-      var redirectTo =  Kong.Auth.getRedirectTo('{{portal.redirect.login}}')
 
 
       // Handle form state
@@ -55,12 +54,14 @@
             type: authType,
             fields: fields
           }).then(() => {
-            window.location.href = redirectTo;
+            window.location.href = Kong.Auth.getRedirectTo('{{portal.redirect.login}}');
           }).catch(onError)
         } else if (accountIsPendingEmailVerfication) {
           alert(accountIsPendingEmailVerificationMessage)
+          window.location.href = '';
         } else {
           alert(accountisPendingVerificationMessage)
+          window.location.href = '';
         }
       }
 

--- a/workspaces/default/themes/light-theme/partials/auth/forms/register/key-auth.html
+++ b/workspaces/default/themes/light-theme/partials/auth/forms/register/key-auth.html
@@ -56,10 +56,10 @@
           }).catch(onError)
         } else if (accountIsPendingEmailVerfication) {
           alert(accountIsPendingEmailVerificationMessage)
-          window.location.href = '';
+          window.location.href = Kong.Auth.getRedirectTo('{{portal.redirect.pending_email_verification}}');
         } else {
           alert(accountisPendingVerificationMessage)
-          window.location.href = '';
+          window.location.href = Kong.Auth.getRedirectTo('{{portal.redirect.pending_approval}}');
         }
       }
 

--- a/workspaces/default/themes/light-theme/partials/auth/forms/register/key-auth.html
+++ b/workspaces/default/themes/light-theme/partials/auth/forms/register/key-auth.html
@@ -31,7 +31,6 @@
       // Submission variables
       var baseApiUrl = window.Kong.getApiUrl();
       var authType = Kong.Auth.KEY_AUTH;
-      var redirectTo =  Kong.Auth.getRedirectTo('{{portal.redirect.login}}')
 
 
       // Handle form state
@@ -53,12 +52,14 @@
             type: authType,
             fields: fields
           }).then(() => {
-            window.location.href = redirectTo;
+            window.location.href = Kong.Auth.getRedirectTo('{{portal.redirect.login}}');
           }).catch(onError)
         } else if (accountIsPendingEmailVerfication) {
           alert(accountIsPendingEmailVerificationMessage)
+          window.location.href = '';
         } else {
           alert(accountisPendingVerificationMessage)
+          window.location.href = '';
         }
       }
 

--- a/workspaces/default/themes/light-theme/partials/auth/forms/register/oidc.html
+++ b/workspaces/default/themes/light-theme/partials/auth/forms/register/oidc.html
@@ -45,13 +45,13 @@
         var accountIsPendingEmailVerfication = data.developer.status === 5
 
         if (accountIsApproved) {
-          window.location.href = "{{page():redirect('login')()}}";
+          window.location.href = Kong.Auth.getRedirectTo('{{portal.redirect.login}}');
         } else if (accountIsPendingEmailVerfication) {
           alert(accountIsPendingEmailVerificationMessage)
-          window.location.href = '';
+          window.location.href = Kong.Auth.getRedirectTo('{{portal.redirect.pending_email_verification}}');
         } else {
           alert(accountisPendingVerificationMessage)
-          window.location.href = '';
+          window.location.href = Kong.Auth.getRedirectTo('{{portal.redirect.pending_approval}}');
         }
       }
 

--- a/workspaces/default/themes/light-theme/partials/auth/forms/register/oidc.html
+++ b/workspaces/default/themes/light-theme/partials/auth/forms/register/oidc.html
@@ -48,8 +48,10 @@
           window.location.href = "{{page():redirect('login')()}}";
         } else if (accountIsPendingEmailVerfication) {
           alert(accountIsPendingEmailVerificationMessage)
+          window.location.href = '';
         } else {
           alert(accountisPendingVerificationMessage)
+          window.location.href = '';
         }
       }
 


### PR DESCRIPTION
Adds `pending_approval` and `pending_email_verification` redirects to portal.conf. They are defaulted to index (''). Now redirects here when registering and not auto approved.

Also fixed the syntax in the oidc template. It was using the old syntax 
```
"{{page():redirect('login')()}}"
```

