### PR TITLE
fix(homepage) hide "create developer" button when auth is disabled - EBB-232

### DIFF
--- a/workspaces/default/themes/light-theme/partials/homepage/hero.html
+++ b/workspaces/default/themes/light-theme/partials/homepage/hero.html
@@ -9,6 +9,8 @@
   </div>
 
   <div class="hero-footer">
-    <a class="btn btn-primary" href="register">Create a Developer Account</a>
+    {% if portal.auth and portal.auth ~= "" then %}
+      <a class="btn btn-primary" href="register">Create a Developer Account</a>
+    {% end %}
   </div>
 </section>


### PR DESCRIPTION
This PR hides the `Register Developer` button on the homepage if auth is disabled. 



