### PR TITLE
fix(homepage): limits catalog to 4 and has state for zero & >4

### DIFF
--- a/workspaces/default/themes/light-theme/partials/homepage/catalog.html
+++ b/workspaces/default/themes/light-theme/partials/homepage/catalog.html
@@ -1,11 +1,20 @@
 <section class="homepage-catalog">
   <div class="catalog-list">
-    {% for _, spec in each(portal.specs) do %}
+    {% for i = 1, 4 do %}
+      {% local spec = portal.specs[i] %}
+      {% if not spec then %}
+        {% break %}
+      {% end %}
       {(partials/service-catalog/item.html, spec)}
     {% end %}
   </div>
-
+  {% if #portal.specs ~= 0 then %}
   <div class="catalog-footer">
+    {% if #portal.specs > 4 then %}
+    <a href="documentation">View all {{#portal.specs}} at the Service Catalog</a>
+    {% else %}
     <a href="documentation">View Catalog</a>
+    {% end %}
   </div>
+  {% end %}
 </section>


### PR DESCRIPTION
Limits catalog on home page to 4 items

If zero items remove link to catalog
If truncating catalog list, then change copy to "View all #NUMBER at the Service Catalog"

<img width="1723" alt="Screen Shot 2019-10-23 at 5 45 24 PM" src="https://user-images.githubusercontent.com/15886900/67444307-419dde80-f5bd-11e9-992c-dfc47175c94c.png">
