### PR TITLE
fix(css): remove page from layouts that are not page EBB-293

### DIFF
--- a/workspaces/default/themes/base/assets/styles/site.css
+++ b/workspaces/default/themes/base/assets/styles/site.css
@@ -809,7 +809,7 @@ a.tag-link.is-active {
  * Page -- Auth (Basic Auth / Key Auth / OIDC)
  *****************************************/
 
- .page.dashboard {
+ .page .dashboard {
    padding: 2em 0;
  }
 

--- a/workspaces/default/themes/base/layouts/system/dashboard.html
+++ b/workspaces/default/themes/base/layouts/system/dashboard.html
@@ -1,7 +1,7 @@
 {% layout = "layouts/_page.html" %}
 
 {-content-}
-<div class="page dashboard">
+<div class="dashboard">
   <div id="portal-dashboard" page="dashboard"></div>
 </div>
 

--- a/workspaces/default/themes/base/layouts/system/invalidate-verification.html
+++ b/workspaces/default/themes/base/layouts/system/invalidate-verification.html
@@ -1,7 +1,7 @@
 {% layout = "layouts/_page.html" %}
 
 {-content-}
-<div class="page dashboard">
+<div class="dashboard">
   <div id="portal-dashboard" page="invalidate-account-verification"></div>
 </div>
 

--- a/workspaces/default/themes/base/layouts/system/resend-verification.html
+++ b/workspaces/default/themes/base/layouts/system/resend-verification.html
@@ -1,7 +1,7 @@
 {% layout = "layouts/_page.html" %}
 
 {-content-}
-<div class="page dashboard">
+<div class="dashboard">
   <div id="portal-dashboard" page="resend-account-verification"></div>
 </div>
 

--- a/workspaces/default/themes/base/layouts/system/settings.html
+++ b/workspaces/default/themes/base/layouts/system/settings.html
@@ -1,7 +1,7 @@
 {% layout = "layouts/_page.html" %}
 
 {-content-}
-<div class="page dashboard">
+<div class="dashboard">
   <div id="portal-dashboard" page="settings"></div>
 </div>
 

--- a/workspaces/default/themes/base/layouts/system/verify-account.html
+++ b/workspaces/default/themes/base/layouts/system/verify-account.html
@@ -1,7 +1,7 @@
 {% layout = "layouts/_page.html" %}
 
 {-content-}
-<div class="page dashboard">
+<div class="dashboard">
   <div id="portal-dashboard" page="verify-account"></div>
 </div>
 


### PR DESCRIPTION
Fixes some pages (dashboard/settings/verrifcations ) that showed footer 'below the fold', requiring scrolling to see the footer.

Fixed by removing the page  class from those layouts (they all use _page.html as the layout so they already have one .page css applied)


https://konghq.atlassian.net/browse/EBB-293