### PR TITLE
Pointing to Lua Resty Repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,6 @@ defined in your Kong `kong.conf`.
 
 ## Libraries Used
 
-- [Lua Resty Template](https://handlebarsjs.com/)
+- [Lua Resty Template](https://github.com/bungle/lua-resty-template)
 - [Swagger UI](https://github.com/swagger-api/swagger-ui)
 - [VueJS](https://vuejs.org/)


### PR DESCRIPTION
### Summary

In the Libraries used section, Lua Resty Template points to the handlebarsjs docs.

### Implemenations

1. Updated to point to https://github.com/bungle/lua-resty-template.

### Changed Docs

1. readme.md

### Issues Resolved

1. Typo / bad redirect
