### PR TITLE
fix(swagger): add redirect for oauth2

### DIFF
--- a/workspaces/default/content/oauth2-redirect.txt
+++ b/workspaces/default/content/oauth2-redirect.txt
@@ -1,0 +1,4 @@
+---
+layout: system/oauth2-redirect.html
+comment: This content file is required to support oauth2 redirect for Swagger UI.
+---

--- a/workspaces/default/themes/base/layouts/system/oauth2-redirect.html
+++ b/workspaces/default/themes/base/layouts/system/oauth2-redirect.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en-US">
+<title>Swagger UI: OAuth2 Redirect</title>
+<body onload="run()">
+</body>
+</html>
+<script>
+    'use strict';
+    function run () {
+        var oauth2 = window.opener.swaggerUIRedirectOauth2;
+        var sentState = oauth2.state;
+        var redirectUrl = oauth2.redirectUrl;
+        var isValid, qp, arr;
+
+        if (/code|token|error/.test(window.location.hash)) {
+            qp = window.location.hash.substring(1);
+        } else {
+            qp = location.search.substring(1);
+        }
+
+        arr = qp.split("&")
+        arr.forEach(function (v,i,_arr) { _arr[i] = '"' + v.replace('=', '":"') + '"';})
+        qp = qp ? JSON.parse('{' + arr.join() + '}',
+                function (key, value) {
+                    return key === "" ? value : decodeURIComponent(value)
+                }
+        ) : {}
+
+        isValid = qp.state === sentState
+
+        if ((
+          oauth2.auth.schema.get("flow") === "accessCode"||
+          oauth2.auth.schema.get("flow") === "authorizationCode"
+        ) && !oauth2.auth.code) {
+            if (!isValid) {
+                oauth2.errCb({
+                    authId: oauth2.auth.name,
+                    source: "auth",
+                    level: "warning",
+                    message: "Authorization may be unsafe, passed state was changed in server Passed state wasn't returned from auth server"
+                });
+            }
+
+            if (qp.code) {
+                delete oauth2.state;
+                oauth2.auth.code = qp.code;
+                oauth2.callback({auth: oauth2.auth, redirectUrl: redirectUrl});
+            } else {
+                let oauthErrorMsg
+                if (qp.error) {
+                    oauthErrorMsg = "["+qp.error+"]: " +
+                        (qp.error_description ? qp.error_description+ ". " : "no accessCode received from the server. ") +
+                        (qp.error_uri ? "More info: "+qp.error_uri : "");
+                }
+
+                oauth2.errCb({
+                    authId: oauth2.auth.name,
+                    source: "auth",
+                    level: "error",
+                    message: oauthErrorMsg || "[Authorization failed]: no accessCode received from the server"
+                });
+            }
+        } else {
+            oauth2.callback({auth: oauth2.auth, token: qp, isValid: isValid, redirectUrl: redirectUrl});
+        }
+        window.close();
+    }
+</script>

--- a/workspaces/default/themes/base/layouts/system/spec-renderer.html
+++ b/workspaces/default/themes/base/layouts/system/spec-renderer.html
@@ -45,6 +45,7 @@
         docExpansion: 'list',
         deepLinking: true, // Enables dynamic deep linking for tags and operations
         filter: true,
+        oauth2RedirectUrl: '{* portal.url *}/oauth2-redirect',
         presets: [
           SwaggerUIBundle.presets.apis,
           SwaggerUIBundle.SwaggerUIStandalonePreset


### PR DESCRIPTION
Fix for https://konghq.atlassian.net/browse/FTI-1396

Swagger ui needs this js asset to finish oauth login: https://github.com/swagger-api/swagger-ui/blob/master/dist/oauth2-redirect.html


This PR adds above as a layout, and adds a content file to give it a route. This PR also sets the oauth2RedirectUrl value for swagger ui to correct value.  

After merging,  this PR should also be cherry picked to master.