### PR TITLE
Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: /
+  target-branch: master
+  schedule:
+    interval: daily
+- package-ecosystem: github-actions
+  directory: /
+  target-branch: master
+  schedule:
+    interval: daily


### PR DESCRIPTION
### Summary

Define dependabot to keep npm dependencies and github action up-to-date 