### PR TITLE
chore(ci) change ci triggers from dev-master branch to master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,8 +24,8 @@ pipeline {
     stage('E2E') {
       when {
         anyOf {
-          branch 'dev-master'
-          changeRequest target: 'dev-master'
+          branch 'master'
+          changeRequest target: 'master'
         }
       }
       steps {
@@ -36,7 +36,7 @@ pipeline {
     stage('Portal Files') {
       when {
         anyOf {
-          branch 'dev-master'
+          branch 'master'
         }
       }
       steps {


### PR DESCRIPTION
Update the branch that triggers CI from `dev-master` to `master` in the Jenkinsfile. Moving forward we will merge PRs into `master` rather than `dev-master`, unless they depend on specific changes in kong-ee.