### PR TITLE
docs(updating) add instructions to update portal templates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,10 @@ defined in your Kong `kong.conf`.
 - [Working with Templates](https://docs.konghq.com/enterprise/1.3-x/developer-portal/working-with-templates/)
 - [Portal CLI](https://docs.konghq.com/enterprise/1.3-x/developer-portal/helpers/cli/)
 
+### Template Updates
+
+To integrate updates from this repo into your portal, see the doc at [updating.md](updating.md)
+
 ## Libraries Used
 
 - [Lua Resty Template](https://github.com/bungle/lua-resty-template)

--- a/updating.md
+++ b/updating.md
@@ -1,0 +1,58 @@
+# Updating kong-portal-templates
+
+## Updating all changes in Portal Templates
+
+Get the latest updates from this repo in your portal by merging in changes from the `master` branch, like this:
+
+1. Ensure that you are a tracking Kong's remote repo with `git remote -v`
+    - Look for the remote that is tracking Kong's remote repo, in this case it is named `kong`
+
+        ```bash
+        git remote -v | grep 'Kong/kong-portal-templates'
+        # kong  git@github.com:Kong/kong-portal-templates.git (fetch)
+        # kong  git@github.com:Kong/kong-portal-templates.git (push)
+        ```
+
+    - If you don't have any output above, add Kong's remote
+
+        ```bash
+        git remote add kong git@github.com:Kong/kong-portal-templates.git
+        ```
+
+2. Create a local branch called `kong-master` that tracks Kong's remote `master` branch
+    - Create new branch `kong-master`
+
+        ```bash
+        git fetch kong master:kong-master
+        ```
+
+    - Note: if you have already done the above for a past update, you can instead get the latest updates:
+
+        ```bash
+        git checkout kong-master
+        git pull
+        ```
+
+3. Merge `kong-master` into your local development branch
+
+    ```bash
+    git checkout <your_development_branch>
+    git merge kong-master
+    # Address any merge conflicts and complete the merge
+    ```
+
+## Manually updating swagger-ui-kong-theme
+
+Note: Updating the theme can also be done by merging all the changes from the `master` branch as described above. If you only want to update Kong's Swagger UI theme, you can do it manually like this:
+
+1. Download the new version of `swagger-ui-kong-theme-<HASH>.min.js`:
+    - **Raw:** [https://raw.githubusercontent.com/Kong/kong-portal-templates/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-c0e498a.min.js](https://raw.githubusercontent.com/Kong/kong-portal-templates/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-c0e498a.min.js)
+    - **Github:** [https://github.com/Kong/kong-portal-templates/blob/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-c0e498a.min.js](https://github.com/Kong/kong-portal-templates/blob/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-c0e498a.min.js)
+2. Place in your workspace at `workspaces/<space>/themes/base/assets/js/swagger-ui-kong-theme-c0e498a.min.js`
+3. Open `workspaces/<space>/themes/base/layouts/system/spec-renderer.html` and update the `<script src=""></script>` tag that imports the theme
+
+    ```html
+    <script src="assets/js/swagger-ui-kong-theme-c0e498a.min.js"></script>
+    ```
+
+4. Delete the old theme file at `workspaces/<space>/themes/base/assets/js/swagger-ui-kong-theme-<OLDHASH>.min.js`

--- a/updating.md
+++ b/updating.md
@@ -48,13 +48,36 @@ Apply the latest updates to your `default` workspace by merging in changes from 
 > Note: Updating the theme for the `default` workspace can also be done by merging all the changes from the `master` branch as described above. If you only want to update Kong's Swagger UI theme, you can do it manually like this:
 
 1. Download the new version of `swagger-ui-kong-theme-<HASH>.min.js`:
-    - **Raw:** [https://raw.githubusercontent.com/Kong/kong-portal-templates/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-c0e498a.min.js](https://raw.githubusercontent.com/Kong/kong-portal-templates/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-c0e498a.min.js)
-    - **Github:** [https://github.com/Kong/kong-portal-templates/blob/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-c0e498a.min.js](https://github.com/Kong/kong-portal-templates/blob/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-c0e498a.min.js)
-2. Place in your workspace at `workspaces/<space>/themes/base/assets/js/swagger-ui-kong-theme-c0e498a.min.js`
+    - **Raw:** [https://raw.githubusercontent.com/Kong/kong-portal-templates/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-dcc10d8.min.js](https://raw.githubusercontent.com/Kong/kong-portal-templates/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-dcc10d8.min.js)
+    - **Github:** [https://github.com/Kong/kong-portal-templates/blob/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-dcc10d8.min.js](https://github.com/Kong/kong-portal-templates/blob/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-dcc10d8.min.js)
+2. Place in your workspace at `workspaces/<space>/themes/base/assets/js/swagger-ui-kong-theme-dcc10d8.min.js`
 3. Open `workspaces/<space>/themes/base/layouts/system/spec-renderer.html` and update the `<script src=""></script>` tag that imports the theme
 
     ```html
-    <script src="assets/js/swagger-ui-kong-theme-c0e498a.min.js"></script>
+    <script src="assets/js/swagger-ui-kong-theme-dcc10d8.min.js"></script>
     ```
 
 4. Delete the old theme file at `workspaces/<space>/themes/base/assets/js/swagger-ui-kong-theme-<OLDHASH>.min.js`
+
+## Manually updating swagger-ui-bundle (swagger UI version)
+
+> Note: Updating the theme for the `default` workspace can also be done by merging all the changes from the `master` branch as described above. If you only want to update Kong's Swagger UI bundle (swagger UI version), you can do it manually like this:
+
+1. Download the new version of `swagger-ui-bundle-<SWAGGER-UI-VERSION>.min.js`:
+    - **Raw:** [https://raw.githubusercontent.com/Kong/kong-portal-templates/master/workspaces/default/themes/base/assets/js/third-party/swagger-ui-bundle-3.26.0.min.js](https://raw.githubusercontent.com/Kong/kong-portal-templates/master/workspaces/default/themes/base/assets/js/third-party/swagger-ui-bundle-3.26.0.min.js)
+    - **Github:** [https://github.com/Kong/kong-portal-templates/blob/master/workspaces/default/themes/base/assets/js/third-party/swagger-ui-bundle-3.26.0.min.js](https://github.com/Kong/kong-portal-templates/blob/master/workspaces/default/themes/base/assets/js/third-party/swagger-ui-bundle-3.26.0.min.js)
+2. Place in your workspace at `workspaces/<space>/themes/base/assets/js/third-party/swagger-ui-bundle-3.26.0.min.js`
+3. Open `workspaces/<space>/themes/base/layouts/system/spec-renderer.html` and update the `<script src=""></script>` tag that imports the swagger ui bundle
+
+    ```html
+    <script src="assets/js/third-party/swagger-ui-bundle-3.26.0.min.js"></script>
+    ```
+
+4. (If Applicable) Delete any swagger ui bundle script tags in `workspaces/<space>/themes/base/layouts/system/spec-renderer.html` that do not include `<SWAGGER-UI-VERSION>` in the bundled file name. Older versions of the templates do not include the version in the file name and should be replaced by the tag from step #3 above. Example of old swagger ui bundle script tag to delete:
+
+    ```html
+    <!-- Delete this tag if found -->
+    <script src="assets/js/third-party/swagger-ui-bundle.min.js"></script>
+    ```
+
+5. Delete the old swagger ui bundle file at `workspaces/<space>/themes/base/assets/js/third-party/swagger-ui-bundle-<OLD-SWAGGER-UI-VERSION>.min.js` or `workspaces/<space>/themes/base/assets/js/third-party/swagger-ui-bundle.min.js` for older templates that did not include the swagger ui bundle version in the file name.

--- a/updating.md
+++ b/updating.md
@@ -48,13 +48,13 @@ Apply the latest updates to your `default` workspace by merging in changes from 
 > Note: Updating the theme for the `default` workspace can also be done by merging all the changes from the `master` branch as described above. If you only want to update Kong's Swagger UI theme, you can do it manually like this:
 
 1. Download the new version of `swagger-ui-kong-theme-<HASH>.min.js`:
-    - **Raw:** [https://raw.githubusercontent.com/Kong/kong-portal-templates/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-dcc10d8.min.js](https://raw.githubusercontent.com/Kong/kong-portal-templates/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-dcc10d8.min.js)
-    - **Github:** [https://github.com/Kong/kong-portal-templates/blob/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-dcc10d8.min.js](https://github.com/Kong/kong-portal-templates/blob/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-dcc10d8.min.js)
-2. Place in your workspace at `workspaces/<space>/themes/base/assets/js/swagger-ui-kong-theme-dcc10d8.min.js`
+    - **Raw:** [https://raw.githubusercontent.com/Kong/kong-portal-templates/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-180e210.min.js](https://raw.githubusercontent.com/Kong/kong-portal-templates/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-180e210.min.js)
+    - **Github:** [https://github.com/Kong/kong-portal-templates/blob/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-180e210.min.js](https://github.com/Kong/kong-portal-templates/blob/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-180e210.min.js)
+2. Place in your workspace at `workspaces/<space>/themes/base/assets/js/swagger-ui-kong-theme-180e210.min.js`
 3. Open `workspaces/<space>/themes/base/layouts/system/spec-renderer.html` and update the `<script src=""></script>` tag that imports the theme
 
     ```html
-    <script src="assets/js/swagger-ui-kong-theme-dcc10d8.min.js"></script>
+    <script src="assets/js/swagger-ui-kong-theme-180e210.min.js"></script>
     ```
 
 4. Delete the old theme file at `workspaces/<space>/themes/base/assets/js/swagger-ui-kong-theme-<OLDHASH>.min.js`

--- a/updating.md
+++ b/updating.md
@@ -2,7 +2,9 @@
 
 ## Updating all changes in Portal Templates
 
-Get the latest updates from this repo in your portal by merging in changes from the `master` branch, like this:
+Apply the latest updates to your `default` workspace by merging in changes from the `master` branch.
+
+> Note: This will only update the `default` workspace. For updating other workspaces, you must integrate changes manually. See the section "Manually updating swagger-ui-kong-theme" below for how to do this for the swagger-ui-kong-theme.
 
 1. Ensure that you are a tracking Kong's remote repo with `git remote -v`
     - Look for the remote that is tracking Kong's remote repo, in this case it is named `kong`
@@ -43,7 +45,7 @@ Get the latest updates from this repo in your portal by merging in changes from 
 
 ## Manually updating swagger-ui-kong-theme
 
-Note: Updating the theme can also be done by merging all the changes from the `master` branch as described above. If you only want to update Kong's Swagger UI theme, you can do it manually like this:
+> Note: Updating the theme for the `default` workspace can also be done by merging all the changes from the `master` branch as described above. If you only want to update Kong's Swagger UI theme, you can do it manually like this:
 
 1. Download the new version of `swagger-ui-kong-theme-<HASH>.min.js`:
     - **Raw:** [https://raw.githubusercontent.com/Kong/kong-portal-templates/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-c0e498a.min.js](https://raw.githubusercontent.com/Kong/kong-portal-templates/master/workspaces/default/themes/base/assets/js/swagger-ui-kong-theme-c0e498a.min.js)


### PR DESCRIPTION
### Summary

Adds a guide for updating portal templates with the latest changes in this repo

### Changed Docs

1. added `updating.md` describing how to update the `default` workspace, as well as manually update the `swagger-ui-kong-theme` for any workspace
2. `readme.md` now links to `updating.md`