### PR TITLE
fix(auth): use email type on email inputs to add sanitization [TDX-1317]

### DIFF
--- a/workspaces/default/themes/base/partials/auth/forms/login/basic-auth.html
+++ b/workspaces/default/themes/base/partials/auth/forms/login/basic-auth.html
@@ -2,7 +2,7 @@
     <p class="form-error-message toggle-content"></p>
 
     <label for="email">{{l("login_form_email_label", "Email")}}</label>
-    <input id="email" type="text" name="email" required />
+    <input id="email" type="email" name="email" required />
 
     <label for="password">{{l("login_form_password_label", "Password")}}</label>
     <input id="password" type="password" name="password" required />

--- a/workspaces/default/themes/base/partials/auth/forms/login/key-auth.html
+++ b/workspaces/default/themes/base/partials/auth/forms/login/key-auth.html
@@ -2,7 +2,7 @@
     <p class="form-error-message toggle-content"></p>
 
     <label for="email">{{l("login_form_email_label", "Email")}}</label>
-    <input id="email" type="text" name="email" required />
+    <input id="email" type="email" name="email" required />
 
     <label for="key">{{l("login_form_key_label", "Key")}}</label>
     <input id="key" type="password" name="key" required />

--- a/workspaces/default/themes/base/partials/auth/forms/register/basic-auth.html
+++ b/workspaces/default/themes/base/partials/auth/forms/register/basic-auth.html
@@ -4,7 +4,7 @@
     {(partials/auth/custom-fields.html, context)}
 
     <label for="email">{{l("register_form_email_label", "Email")}}</label>
-    <input id="email" type="text" name="email" required />
+    <input id="email" type="email" name="email" required />
     <p class="field-error toggle-content" for="email"></p>
 
     <label for="password">{{l("register_form_password_label", "Password")}}</label>

--- a/workspaces/default/themes/base/partials/auth/forms/register/key-auth.html
+++ b/workspaces/default/themes/base/partials/auth/forms/register/key-auth.html
@@ -2,7 +2,7 @@
     {(partials/auth/custom-fields.html, context)}
 
     <label for="email">{{l("register_form_email_label", "Email")}}</label>
-    <input id="email" type="text" name="email" required />
+    <input id="email" type="email" name="email" required />
     <p class="field-error toggle-content" for="email"></p>
 
     <label for="key">{{l("register_form_key_label", "Key")}}</label>

--- a/workspaces/default/themes/base/partials/auth/forms/register/oidc.html
+++ b/workspaces/default/themes/base/partials/auth/forms/register/oidc.html
@@ -4,7 +4,7 @@
     {(partials/auth/custom-fields.html, context)}
 
     <label for="email">{{l("register_form_email_label", "Email")}}</label>
-    <input id="email" type="text" name="email" required />
+    <input id="email" type="email" name="email" required />
     <p class="field-error toggle-content" for="email"></p>
 
     <button


### PR DESCRIPTION
using `type="email"` lets the browser help sanitize the form for you.

### Summary
This prevents the user from injecting HTML into the `email` input on various pages.

### Implementations

1. Replaced all `<input name="email" type="text" />` with `type="email"` where appropriate.

### Changed Docs

1. None

### Issues Resolved

1. TDX-1317




