### PR TITLE
fix(auth): renders response fields as text rather than as html [TDX-1317]

### DIFF
--- a/workspaces/default/themes/base/partials/auth/forms/login/basic-auth.html
+++ b/workspaces/default/themes/base/partials/auth/forms/login/basic-auth.html
@@ -33,7 +33,7 @@
       var onSubmit = function() {
         $FORM_ERROR
           .removeClass('is-visible')
-          .html('');
+          .text('');
 
         Kong.Auth.login({
           baseUrl: baseApiUrl,
@@ -49,7 +49,7 @@
       var onError = function(data) {
         $FORM_ERROR
           .addClass('is-visible')
-          .html(data.message || 'An unexpected error occurred. Please try again.');
+          .text(data.message || 'An unexpected error occurred. Please try again.');
       }
 
 

--- a/workspaces/default/themes/base/partials/auth/forms/login/key-auth.html
+++ b/workspaces/default/themes/base/partials/auth/forms/login/key-auth.html
@@ -33,7 +33,7 @@
       var onSubmit = function() {
         $FORM_ERROR
           .removeClass('is-visible')
-          .html('');
+          .text('');
 
         Kong.Auth.login({
           baseUrl: baseApiUrl,
@@ -49,7 +49,7 @@
       var onError = function(data) {
         $FORM_ERROR
           .addClass('is-visible')
-          .html(data.message || 'An unexpected error occurred. Please try again.');
+          .text(data.message || 'An unexpected error occurred. Please try again.');
       }
 
 

--- a/workspaces/default/themes/base/partials/auth/forms/login/oidc.html
+++ b/workspaces/default/themes/base/partials/auth/forms/login/oidc.html
@@ -20,7 +20,7 @@
       var onSubmit = function() {
         $FORM_ERROR
           .removeClass('is-visible')
-          .html('');
+          .text('');
 
         Kong.Auth.loginWithOpenIdConnect({
           baseUrl: baseApiUrl,
@@ -31,7 +31,7 @@
       var onError = function(data) {
         $FORM_ERROR
           .addClass('is-visible')
-          .html(data.message || 'An unexpected error occurred. Please try again.');
+          .text(data.message || 'An unexpected error occurred. Please try again.');
       }
 
 

--- a/workspaces/default/themes/base/partials/auth/forms/register/basic-auth.html
+++ b/workspaces/default/themes/base/partials/auth/forms/register/basic-auth.html
@@ -4,7 +4,7 @@
     {(partials/auth/custom-fields.html, context)}
 
     <label for="email">{{l("register_form_email_label", "Email")}}</label>
-    <input id="email" type="email" name="email" required />
+    <input id="email" type="string" name="email" required />
     <p class="field-error toggle-content" for="email"></p>
 
     <label for="password">{{l("register_form_password_label", "Password")}}</label>
@@ -73,12 +73,12 @@
               .addClass('has-error')
             $(".field-error[for='" + field + "']")
               .addClass('is-visible')
-              .html(response.fields[field])
+              .text(response.fields[field])
           }
         } else {
           $FORM_ERROR
             .addClass('is-visible')
-            .html(data.message || fallbackErrorMessage);
+            .text(data.message || fallbackErrorMessage);
         }
       }
 
@@ -87,7 +87,7 @@
       $FORM.on('submit', function(event) {
         event.preventDefault();
         $('.has-error').removeClass('has-error');
-        $('.is-visible').removeClass('is-visible').html('');
+        $('.is-visible').removeClass('is-visible').text('');
         fields = $FORM.serializeArray()
         onSubmit();
       })

--- a/workspaces/default/themes/base/partials/auth/forms/register/key-auth.html
+++ b/workspaces/default/themes/base/partials/auth/forms/register/key-auth.html
@@ -71,12 +71,12 @@
               .addClass('has-error')
             $(".field-error[for='" + field + "']")
               .addClass('is-visible')
-              .html(response.fields[field])
+              .text(response.fields[field])
           }
         } else {
           $FORM_ERROR
             .addClass('is-visible')
-            .html(data.message || fallbackErrorMessage);
+            .text(data.message || fallbackErrorMessage);
         }
       }
 
@@ -85,7 +85,7 @@
       $FORM.on('submit', function(event) {
         event.preventDefault();
         $('.has-error').removeClass('has-error');
-        $('.is-visible').removeClass('is-visible').html('');
+        $('.is-visible').removeClass('is-visible').text('');
         fields = $FORM.serializeArray()
         onSubmit();
       })

--- a/workspaces/default/themes/base/partials/auth/forms/register/oidc.html
+++ b/workspaces/default/themes/base/partials/auth/forms/register/oidc.html
@@ -63,12 +63,12 @@
               .addClass('has-error')
             $(".field-error[for='" + field + "']")
               .addClass('is-visible')
-              .html(response.fields[field])
+              .text(response.fields[field])
           }
         } else {
           $FORM_ERROR
             .addClass('is-visible')
-            .html(data.message || fallbackErrorMessage);
+            .text(data.message || fallbackErrorMessage);
         }
       }
 
@@ -77,7 +77,7 @@
       $FORM.on('submit', function(event) {
         event.preventDefault();
         $('.has-error').removeClass('has-error');
-        $('.is-visible').removeClass('is-visible').html('');
+        $('.is-visible').removeClass('is-visible').text('');
         fields = $FORM.serializeArray()
         onSubmit();
       })

--- a/workspaces/default/themes/base/partials/service-catalog/sidebar.html
+++ b/workspaces/default/themes/base/partials/service-catalog/sidebar.html
@@ -57,7 +57,7 @@
       Object.keys(tags).forEach(function(tag) {
         var elem = $CATALOG_TAG_LINKS.filter('[data-tag="' + tag + '"]');
         var count = tags[tag];
-        elem.find(".tag-link--count").html(count);
+        elem.find(".tag-link--count").text(count);
 
         if (elem.hasClass('is-active') && count === 0) {
           $CATALOG_LIST_NO_RESULTS.show();


### PR DESCRIPTION
### Summary

So! My last PR was doing part of the work, but the _actual_ problem was in using `JQuery.html` on any response from the API, whose value was created reflectively from the email input. By replacing all of the `$.html` with `$.text` this _should_ resolve the issue (I have tested this locally).

That being said, I'm not sure if there were use cases that I would've missed via context or otherwise that would have it be advantageous to use `.html()`. I'm going to defer to others, but from my cursory perusal of the codebase, I can't see anywhere that a `.text` wouldn't be a suitable replacement.
<!---- Please write summery as elaborative as you can it will help the contributors ---->


### Issues Resolved

1. TDX-1317, but more robustly.




