### PR TITLE
fix(menu): fix menu styling so that it shows correctly

### DIFF
--- a/workspaces/default/themes/base/assets/styles/site.css
+++ b/workspaces/default/themes/base/assets/styles/site.css
@@ -158,7 +158,7 @@ input.has-error {
   justify-content: space-between;
 }
 
-.site-header .top-menu {
+.site-header nav > .top-menu {
   margin-bottom: unset;
 }
 
@@ -266,11 +266,18 @@ input.has-error {
     transition: all 0.5s ease;
     z-index: 99;
     left: 0;
-    right: 0;
     border-radius: 8px;
     box-shadow: 0 5px 10px rgba(0,0,0,0.3);
     padding-top: 1em;
     display: none;
+  }
+
+  .site-header nav li.has-dropdown ul {
+    top: 2.1em;
+    left: .8em;
+    padding: unset;
+    margin: unset;
+    text-align: left;
   }
 
   .site-header nav > .has-dropdown:hover > a {
@@ -282,7 +289,7 @@ input.has-error {
   .site-header nav li ul:hover {
     visibility: visible;
     opacity: 1;
-    display: block;
+    display: inline-block;
   }
 
   /* Keyboard user support */

--- a/workspaces/default/themes/base/partials/menu.html
+++ b/workspaces/default/themes/base/partials/menu.html
@@ -23,18 +23,14 @@
           <li {* menu_class *}><a href="{{menu_entry.url}}">{{menu_entry.title}}</a>
           {% if menu_entry.sub_menu then %}
             {% context.local_menu = menu_entry.sub_menu %}
-            <ul>
             {(partials/menu.html)}
-            </ul>
           {% end %}
         {% end %}
       {% else %}
         <li {* menu_class *}><a href="{{menu_entry.url}}">{{menu_entry.title}}</a>
         {% if menu_entry.sub_menu then %}
           {% context.local_menu = menu_entry.sub_menu %}
-          <ul>
            {(partials/menu.html)}
-          </ul>
         {% end %}
       {% end %}
     {% end %}
@@ -46,18 +42,14 @@
         <li {* menu_class *}><a href="{{menu_entry.url}}">{{menu_entry.title}}</a>
         {% if menu_entry.sub_menu then %}
           {% context.local_menu = menu_entry.sub_menu %}
-          <ul>
            {(partials/menu.html)}
-          </ul>
         {% end %}
       {% end %}
     {% else %}
       <li {* menu_class *}><a href="{{menu_entry.url}}">{{menu_entry.title}}</a>
       {% if menu_entry.sub_menu then %}
         {% context.local_menu = menu_entry.sub_menu %}
-        <ul>
          {(partials/menu.html)}
-        </ul>
       {% end %}
     {% end %}
   {% end %}


### PR DESCRIPTION
needed to fix some css and remove some nested <ul>s

fix TDX-1547

### Summary

After changing the nested stylings to be wrapped in a `ul`, we neglected to update the CSS for that dropdown so that it would remain visible for users.

Before:
![image](https://user-images.githubusercontent.com/2126677/134737935-6093ee7e-f51b-400e-907e-0eb1c0e2cc43.png)

After:
![image](https://user-images.githubusercontent.com/2126677/134737986-fce143cf-ed28-4b37-9895-3cca2f677d7f.png)





