### PR TITLE
style: update the auth page to use css instead of h3 for a11y fix

### DIFF
--- a/workspaces/default/themes/base/assets/styles/site.css
+++ b/workspaces/default/themes/base/assets/styles/site.css
@@ -803,6 +803,22 @@ a.tag-link.is-active {
   width: 40rem;
 }
 
+.auth-page .left-pane .inner .title {
+  color: var(--text_headings,  #888888);
+  font-size: 3rem;
+  line-height: 1.3;
+  margin-top: 0;
+  margin-bottom: 2rem;
+  font-weight: 500;
+  font-family: "Lato", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+}
+
+@media (min-width: 550px) {
+  .auth-page .left-pane .inner .title {
+    font-size: 3.6rem;
+  }
+}
+
 .auth-page .left-pane input {
   width: 100%;
 }

--- a/workspaces/default/themes/base/layouts/system/login.html
+++ b/workspaces/default/themes/base/layouts/system/login.html
@@ -4,7 +4,7 @@
   <div class="auth-page">
     <section class="left-pane">
       <div class="inner">
-        <h3>{* l("login_form_header", "Login") *}</h3>
+        <p class="title">{* l("login_form_header", "Login") *}</p>
         <p>{* l("login_form_content", "Use your credentials to access your account.") *}</p>
 
         {% if portal.auth == 'basic-auth' then %}

--- a/workspaces/default/themes/base/layouts/system/register.html
+++ b/workspaces/default/themes/base/layouts/system/register.html
@@ -4,7 +4,7 @@
   <div class="auth-page">
     <section class="left-pane">
       <div class="inner">
-        <h3>{* l("register_form_header", "Register") *}</h3>
+        <p class="title">{* l("register_form_header", "Register") *}</p>
         <p>{* l("register_form_content", "Enter your information below to create an account.") *}</p>
 
         {% if portal.auth == 'basic-auth' then %}


### PR DESCRIPTION
### Summary
The login / register pages were using an h3, and aXe would throw an error since there are no other header level tags. Replaced this with css styling and a `p` tag instead.


### Implementations

1.
2.
3.
4.

### Changed Docs

1.
2.
3.
4.

### Issues Resolved

1.
2.
3.
4.




