### PR TITLE
fix(catalog) update default catalog filter text [TDX-1574]

### DIFF
--- a/workspaces/default/content/documentation/index.txt
+++ b/workspaces/default/content/documentation/index.txt
@@ -7,5 +7,5 @@ hide_categories: false
 locale:
   catalog_no_results_header: "No Results Found"
   catalog_no_results_content: "No services matched your criteria. Try another query?"
-  catalog_categories_header_text: "Category"
+  catalog_categories_header_text: "Category Filter"
 ---

--- a/workspaces/default/themes/base/partials/service-catalog/sidebar.html
+++ b/workspaces/default/themes/base/partials/service-catalog/sidebar.html
@@ -1,7 +1,7 @@
 {% if not page.hide_categories then %}
 <div class="catalog-sidebar">
   <div class="catalog-categories-component">
-    <h5>{{ l("catalog_categories_header_text", "Category") }}</h5>
+    <h5>{{ l("catalog_categories_header_text", "Category Filter") }}</h5>
 
     {% for tag, count in each(tags) do %}
     <a data-tag="{{ tag:lower() }}" class="tag-link">


### PR DESCRIPTION
This updates the default value of the `catalog_categories_header_text` variable to be "Category Filter" rather than "Category" so that it is easier to understand how the sidebar works.

Demo:
<img width="1170" alt="Screen Shot 2021-10-29 at 12 58 53 PM" src="https://user-images.githubusercontent.com/8764246/139474422-776bea34-6ce3-44e9-83ff-b439e84c60e5.png">

