### PR TITLE
fix(a11y) ensure headings are nested well in each section [TDX-1602]

### DIFF
--- a/workspaces/default/themes/base/assets/styles/site.css
+++ b/workspaces/default/themes/base/assets/styles/site.css
@@ -844,12 +844,17 @@ a.tag-link.is-active {
   width: 40%;
 }
 
+.auth-page .right-pane .inner h1,
 .auth-page .right-pane .inner h2,
 .auth-page .right-pane .inner h3,
 .auth-page .right-pane .inner h4,
 .auth-page .right-pane .inner h5,
 .auth-page .right-pane .inner p {
   color: var(--text_hero, white);
+}
+
+.auth-page .right-pane .inner h1 {
+  font-size: 3rem;
 }
 
 @media (min-width: 768px) {

--- a/workspaces/default/themes/base/assets/styles/site.css
+++ b/workspaces/default/themes/base/assets/styles/site.css
@@ -442,7 +442,7 @@ a.tag-link .tag-link--name {
 
 a.tag-link .tag-link--count {
   float: right;
-  color: #888;
+  color: #666;
 }
 
 a.tag-link.is-active .tag-link--count {

--- a/workspaces/default/themes/base/assets/styles/site.css
+++ b/workspaces/default/themes/base/assets/styles/site.css
@@ -424,6 +424,10 @@ input.has-error {
  * Component - Catalog Sidebar Tags
  *****************************************/
 
+.catalog-sidebar h1 {
+  font-size: 2.4rem;
+}
+
 a.tag-link {
   display: block;
   padding: .5rem 1rem;

--- a/workspaces/default/themes/base/assets/styles/site.css
+++ b/workspaces/default/themes/base/assets/styles/site.css
@@ -615,8 +615,9 @@ a.tag-link.is-active {
   color: var(--text_hero, #FFFFFF);
 }
 
-.homepage-hero h2 {
+.homepage-hero h1 {
   margin-bottom: 1rem;
+  font-size: 4.2rem;
   color: var(--text_hero, #FFFFFF);
 }
 

--- a/workspaces/default/themes/base/assets/styles/site.css
+++ b/workspaces/default/themes/base/assets/styles/site.css
@@ -407,7 +407,7 @@ input.has-error {
   border-bottom: 1px solid #eee;
 }
 
-.catalog-filter-component h2 {
+.catalog-filter-component h1 {
   color: var(--text_hero, white);
   font-size: 32px;
 }

--- a/workspaces/default/themes/base/assets/styles/site.css
+++ b/workspaces/default/themes/base/assets/styles/site.css
@@ -526,8 +526,8 @@ a.tag-link.is-active {
   text-align: left;
 }
 
-.catalog-item .catalog-details h2.catalog-title {
-  font-size: 2.4 rem;
+.catalog-item .catalog-details h1.catalog-title {
+  font-size: 2.4rem;
 }
 .catalog-item .catalog-details .catalog-title {
   color: var(--text_links, blue);

--- a/workspaces/default/themes/base/layouts/system/login.html
+++ b/workspaces/default/themes/base/layouts/system/login.html
@@ -32,7 +32,7 @@
       <div class="inner">
         <img alt="authorization hero placeholder" src="assets/images/auth-placeholder.svg" />
 
-        <h4>{* l("login_side_header", "") *}</h4>
+        <h1>{* l("login_side_header", "") *}</h1>
         <p>{* l("login_side_content", "") *}</p>
       </div>
     </section>

--- a/workspaces/default/themes/base/layouts/system/register.html
+++ b/workspaces/default/themes/base/layouts/system/register.html
@@ -31,7 +31,7 @@
     <section class="right-pane">
       <div class="inner">
         <img alt="authorization hero placeholder" src="assets/images/auth-placeholder.svg" />
-        <h4>{* l("register_side_header", "") *}</h4>
+        <h1>{* l("register_side_header", "") *}</h1>
         <p>{* l("register_side_content", "") *}</p>
       </div>
     </section>

--- a/workspaces/default/themes/base/partials/homepage/hero.html
+++ b/workspaces/default/themes/base/partials/homepage/hero.html
@@ -1,8 +1,8 @@
 <section class="homepage-hero">
   <div class="hero-header">
-    <h2>
+    <h1>
       {{page.hero.title}}
-    </h2>
+    </h1>
     <p>
       {{page.hero.tagline}}
     </p>

--- a/workspaces/default/themes/base/partials/service-catalog/filter.html
+++ b/workspaces/default/themes/base/partials/service-catalog/filter.html
@@ -1,8 +1,8 @@
 {% if not page.hide_filter then %}
-<div class="catalog-filter-component">
+<section class="catalog-filter-component">
   <div class="container">
-    <h2>What service are you looking for?</h2>
+    <h1>What service are you looking for?</h1>
     <input class="catalog-filter" placeholder="Filter Services..." />
   </div>
-</div>
+</section>
 {% end %}

--- a/workspaces/default/themes/base/partials/service-catalog/item.html
+++ b/workspaces/default/themes/base/partials/service-catalog/item.html
@@ -7,7 +7,7 @@
   </div>
 
   <div class="catalog-details">
-    <h5 class="catalog-title">{{parsed.info.title}}</h5>
+    <h1 class="catalog-title">{{parsed.info.title}}</h1>
 
     {% if parsed.info.description then %}
       <p class="catalog-desc">{{parsed.info.description}}</p>

--- a/workspaces/default/themes/base/partials/service-catalog/list.html
+++ b/workspaces/default/themes/base/partials/service-catalog/list.html
@@ -1,4 +1,4 @@
-<div class="catalog-list">
+<section class="catalog-list">
   {% if #specs > 0 then %}
     {% for _, spec in each(specs) do %}
       {(partials/service-catalog/item.html, spec)}
@@ -8,7 +8,7 @@
       <h4>{{ l("catalog_no_results_header", "Nothing Found, Sorry") }}</h4>
     </div>
   {% end %}
-</div>
+</section>
 
 <div class="catalog-list__no-results toggle-content">
   <h4>{{ l("catalog_no_results_header", "Nothing Found, Sorry") }}</h4>

--- a/workspaces/default/themes/base/partials/service-catalog/sidebar.html
+++ b/workspaces/default/themes/base/partials/service-catalog/sidebar.html
@@ -1,7 +1,7 @@
 {% if not page.hide_categories then %}
-<div class="catalog-sidebar">
+<section class="catalog-sidebar">
   <div class="catalog-categories-component">
-    <h5>{{ l("catalog_categories_header_text", "Category Filter") }}</h5>
+    <h1>{{ l("catalog_categories_header_text", "Category Filter") }}</h1>
 
     {% for tag, count in each(tags) do %}
     <a data-tag="{{ tag:lower() }}" class="tag-link">
@@ -10,7 +10,7 @@
     </a>
     {% end %}
   </div>
-</div>
+</section>
 {% end %}
 
 


### PR DESCRIPTION
Addresses the following issues with headings and color contrast:
- Home /default/
  - `.hero-header h2` changed to h1 under section
  - `.catalog-details h5` changed to h1 under section
- Catalog /default/documentation
  - `.tag-link .tag-link--count` has increased color contrast
  - `.catalog-categories-component h5` changed to h1 under section
- Login /default/login
  - `h4` changed to h1 under section
- Register /default/register
  - `h4` changed to h1 under section