### PR TITLE
fix: add option to show vendor extension fields (TDX-1269)

### DIFF
--- a/workspaces/default/themes/base/layouts/system/spec-renderer.html
+++ b/workspaces/default/themes/base/layouts/system/spec-renderer.html
@@ -49,6 +49,7 @@
         dom_id: '#ui-wrapper', // Determine what element to load swagger ui
         docExpansion: 'list',
         deepLinking: true, // Enables dynamic deep linking for tags and operations
+        showExtensions: false, // Controls the display of vendor extension (x-) fields and values for Operations, Parameters, Responses, and Schema.
         filter: true,
         oauth2RedirectUrl: '{* portal.url *}/oauth2-redirect',
         presets: [


### PR DESCRIPTION
### Summary
This adds the option for Swagger UI in the `spec-renderer` to allow the rendering of vendor extension fields.

### Implementations

1. Added `showExtensions` option for swagger UI, defaulting to false as per TDX-1269.
2.
3.
4.

### Changed Docs

1.
2.
3.
4.

### Issues Resolved

1. TDX-1269
2.
3.
4.




