### PR TITLE
chore(templates): comment out footer links as they are empty placeholders

### DIFF
--- a/workspaces/default/themes/base/partials/footer.html
+++ b/workspaces/default/themes/base/partials/footer.html
@@ -5,10 +5,10 @@
         <h1 class="brand">{{portal.name}}</h1>
       </div>
 
-      <nav class="eight columns" aria-label="Footer Links">
-        <a class="nav-link">Terms of Service</a>
-        <a class="nav-link">Privacy</a>
-      </nav>
+      <!-- <nav class="eight columns" aria-label="Footer Links">
+        <a href="" class="nav-link">Terms of Service</a>
+        <a href="" class="nav-link">Privacy</a>
+      </nav> -->
     </div>
   </div>
 </footer>


### PR DESCRIPTION
### Summary
The footer links aren't actually being utilized so we are going to comment them out in case it leads to any confusion. Users can comment them out once they have pages / templates built for their links.
<!---- Please write summery as elaborative as you can it will help the contributors ---->

### Implementations

1. Commented out the links in the footer.
2.
3.
4.

### Changed Docs

1.
2.
3.
4.

### Issues Resolved

1.
2.
3.
4.




