### PR TITLE
fix(register): update error message when receiving improper error

### DIFF
--- a/workspaces/default/themes/base/assets/js/kong/kong.utils.js
+++ b/workspaces/default/themes/base/assets/js/kong/kong.utils.js
@@ -46,6 +46,11 @@ window.Kong.Utils.serializeFieldsArrayToObject = function (fieldsArray) {
 };
 
 window.Kong.Utils.getErrorMessage = function (response) {
+
+  if (typeof response.message === "string") {
+    return response.message;
+  }
+
   try {
     // we want errors to be unique
     let foundErrors = new Set();

--- a/workspaces/default/themes/base/assets/js/kong/kong.utils.js
+++ b/workspaces/default/themes/base/assets/js/kong/kong.utils.js
@@ -1,46 +1,61 @@
 window.Kong = window.Kong || {}
 window.Kong.Utils = window.Kong.Utils || {}
 
+const fallbackErrorMessage = "An unexpected error occurred. Please try again.";
 
 // Taken from underscore.js | MIT
 // Used for input keydown events
-window.Kong.Utils.debounce = function(func, wait, immediate) {
-	var timeout;
-	return function() {
-		var context = this, args = arguments;
-		var later = function() {
-			timeout = null;
-			if (!immediate) func.apply(context, args);
-		};
-		var callNow = immediate && !timeout;
-		clearTimeout(timeout);
-		timeout = setTimeout(later, wait);
-		if (callNow) func.apply(context, args);
-	};
+window.Kong.Utils.debounce = function (func, wait, immediate) {
+  var timeout;
+  return function () {
+    var context = this,
+      args = arguments;
+    var later = function () {
+      timeout = null;
+      if (!immediate) func.apply(context, args);
+    };
+    var callNow = immediate && !timeout;
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+    if (callNow) func.apply(context, args);
+  };
 };
-
 
 // Taken from StackOverflow | MIT
 // Used for QueryString parsing (ES3+ supported)
 // See login/register forms for usage
-window.Kong.Utils.getParameterByName = function(name, url) {
+window.Kong.Utils.getParameterByName = function (name, url) {
   if (!url) url = window.location.href;
-  name = name.replace(/[\[\]]/g, '\\$&');
-  var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
-      results = regex.exec(url);
+  name = name.replace(/[\[\]]/g, "\\$&");
+  var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+    results = regex.exec(url);
   if (!results) return null;
-  if (!results[2]) return '';
-  return decodeURIComponent(results[2].replace(/\+/g, ' '));
-}
+  if (!results[2]) return "";
+  return decodeURIComponent(results[2].replace(/\+/g, " "));
+};
 
-
-window.Kong.Utils.serializeFieldsArrayToObject = function(fieldsArray) {
-  var output = {}
+window.Kong.Utils.serializeFieldsArrayToObject = function (fieldsArray) {
+  var output = {};
 
   for (var i = 0; i < fieldsArray.length; i++) {
     var field = fieldsArray[i];
     output[field.name] = field.value;
   }
 
-  return output
-}
+  return output;
+};
+
+window.Kong.Utils.getErrorMessage = function (response) {
+  try {
+    // we want errors to be unique
+    let foundErrors = new Set();
+    // Handle SMTP sending errors:
+    for (const email in response.message.error.emails) {
+      const errorMessage = response.message.error.emails[email];
+      foundErrors.add(errorMessage);
+    }
+    return Array.from(foundErrors).join("\n");
+  } catch (error) {
+    return fallbackErrorMessage;
+  }
+};

--- a/workspaces/default/themes/base/partials/auth/forms/register/basic-auth.html
+++ b/workspaces/default/themes/base/partials/auth/forms/register/basic-auth.html
@@ -65,6 +65,20 @@
         }
       }
 
+      var getErrorMessage = function (response) {
+        try {
+          let tmp = '';
+          // Handle SMTP sending errors:
+          for (const email in response.message.error.emails) {
+            const errorMessage = response.message.error.emails[email];
+            tmp += '\n' + errorMessage;
+          }
+          return tmp;
+        } catch (error) {
+          return fallbackErrorMessage;
+        }
+      }
+
       var onError = function(data) {
         var response = data.xhr.responseJSON
         if (response && response.fields) {
@@ -76,7 +90,7 @@
               .text(response.fields[field])
           }
         } else {
-          const uiErrorMessage = data && data.message && typeof data.message  === "string" ? data.message : fallbackErrorMessage;
+          const uiErrorMessage = getErrorMessage(data);
           $FORM_ERROR
             .addClass('is-visible')
             .text(uiErrorMessage);

--- a/workspaces/default/themes/base/partials/auth/forms/register/basic-auth.html
+++ b/workspaces/default/themes/base/partials/auth/forms/register/basic-auth.html
@@ -27,7 +27,6 @@
       // Messaging
       var accountIsPendingEmailVerificationMessage = 'Thank you for registering! Please check your email to verify your account.'
       var accountisPendingVerificationMessage = 'Thank you for registering! Your account is under admin review. You will be emailed once approved.'
-      var fallbackErrorMessage = 'An unexpected error occurred. Please try again.'
 
 
       // Submission variables
@@ -65,20 +64,6 @@
         }
       }
 
-      var getErrorMessage = function (response) {
-        try {
-          let tmp = '';
-          // Handle SMTP sending errors:
-          for (const email in response.message.error.emails) {
-            const errorMessage = response.message.error.emails[email];
-            tmp += '\n' + errorMessage;
-          }
-          return tmp;
-        } catch (error) {
-          return fallbackErrorMessage;
-        }
-      }
-
       var onError = function(data) {
         var response = data.xhr.responseJSON
         if (response && response.fields) {
@@ -90,7 +75,7 @@
               .text(response.fields[field])
           }
         } else {
-          const uiErrorMessage = getErrorMessage(data);
+          const uiErrorMessage = window.Kong.Utils.getErrorMessage(data);
           $FORM_ERROR
             .addClass('is-visible')
             .text(uiErrorMessage);

--- a/workspaces/default/themes/base/partials/auth/forms/register/basic-auth.html
+++ b/workspaces/default/themes/base/partials/auth/forms/register/basic-auth.html
@@ -76,9 +76,10 @@
               .text(response.fields[field])
           }
         } else {
+          const uiErrorMessage = data && data.message && typeof data.message  === "string" ? data.message : fallbackErrorMessage;
           $FORM_ERROR
             .addClass('is-visible')
-            .text(data.message || fallbackErrorMessage);
+            .text(uiErrorMessage);
         }
       }
 

--- a/workspaces/default/themes/base/partials/auth/forms/register/key-auth.html
+++ b/workspaces/default/themes/base/partials/auth/forms/register/key-auth.html
@@ -63,6 +63,20 @@
         }
       }
 
+      var getErrorMessage = function (response) {
+        try {
+          let tmp = '';
+          // Handle SMTP sending errors:
+          for (const email in response.message.error.emails) {
+            const errorMessage = response.message.error.emails[email];
+            tmp += '\n' + errorMessage;
+          }
+          return tmp;
+        } catch (error) {
+          return fallbackErrorMessage;
+        }
+      }
+
       var onError = function(data) {
         var response = data.xhr.responseJSON
         if (response && response.fields) {
@@ -74,7 +88,7 @@
               .text(response.fields[field])
           }
         }  else {
-          const uiErrorMessage = data && data.message && typeof data.message  === "string" ? data.message : fallbackErrorMessage;
+          const uiErrorMessage = getErrorMessage(data);
           $FORM_ERROR
             .addClass('is-visible')
             .text(uiErrorMessage);

--- a/workspaces/default/themes/base/partials/auth/forms/register/key-auth.html
+++ b/workspaces/default/themes/base/partials/auth/forms/register/key-auth.html
@@ -73,10 +73,11 @@
               .addClass('is-visible')
               .text(response.fields[field])
           }
-        } else {
+        }  else {
+          const uiErrorMessage = data && data.message && typeof data.message  === "string" ? data.message : fallbackErrorMessage;
           $FORM_ERROR
             .addClass('is-visible')
-            .text(data.message || fallbackErrorMessage);
+            .text(uiErrorMessage);
         }
       }
 

--- a/workspaces/default/themes/base/partials/auth/forms/register/key-auth.html
+++ b/workspaces/default/themes/base/partials/auth/forms/register/key-auth.html
@@ -25,7 +25,6 @@
       // Messaging
       var accountIsPendingEmailVerificationMessage = 'Thank you for registering! Please check your email to verify your account.'
       var accountisPendingVerificationMessage = 'Thank you for registering! Your account is under admin review. You will be emailed once approved.'
-      var fallbackErrorMessage = 'An unexpected error occurred. Please try again.'
 
 
       // Submission variables
@@ -63,20 +62,6 @@
         }
       }
 
-      var getErrorMessage = function (response) {
-        try {
-          let tmp = '';
-          // Handle SMTP sending errors:
-          for (const email in response.message.error.emails) {
-            const errorMessage = response.message.error.emails[email];
-            tmp += '\n' + errorMessage;
-          }
-          return tmp;
-        } catch (error) {
-          return fallbackErrorMessage;
-        }
-      }
-
       var onError = function(data) {
         var response = data.xhr.responseJSON
         if (response && response.fields) {
@@ -88,7 +73,7 @@
               .text(response.fields[field])
           }
         }  else {
-          const uiErrorMessage = getErrorMessage(data);
+          const uiErrorMessage = window.Kong.Utils.getErrorMessage(data);
           $FORM_ERROR
             .addClass('is-visible')
             .text(uiErrorMessage);

--- a/workspaces/default/themes/base/partials/auth/forms/register/oidc.html
+++ b/workspaces/default/themes/base/partials/auth/forms/register/oidc.html
@@ -33,7 +33,6 @@
       // Messaging
       var accountIsPendingEmailVerificationMessage = 'Thank you for registering! Please check your email to verify your account.'
       var accountisPendingVerificationMessage = 'Thank you for registering! Your account is under admin review. You will be emailed once approved.'
-      var fallbackErrorMessage = 'An unexpected error occurred. Please try again.'
 
 
       // Submission variables
@@ -65,20 +64,6 @@
         }
       }
 
-      var getErrorMessage = function (response) {
-        try {
-          let tmp = '';
-          // Handle SMTP sending errors:
-          for (const email in response.message.error.emails) {
-            const errorMessage = response.message.error.emails[email];
-            tmp += '\n' + errorMessage;
-          }
-          return tmp;
-        } catch (error) {
-          return fallbackErrorMessage;
-        }
-      }
-
       var onError = function(data) {
         var response = data.xhr.responseJSON
         if (response && response.fields) {
@@ -90,7 +75,7 @@
               .text(response.fields[field])
           }
         } else {
-          const uiErrorMessage = getErrorMessage(data);
+          const uiErrorMessage = window.Kong.Utils.getErrorMessage(data);
           $FORM_ERROR
             .addClass('is-visible')
             .text(uiErrorMessage);

--- a/workspaces/default/themes/base/partials/auth/forms/register/oidc.html
+++ b/workspaces/default/themes/base/partials/auth/forms/register/oidc.html
@@ -65,6 +65,20 @@
         }
       }
 
+      var getErrorMessage = function (response) {
+        try {
+          let tmp = '';
+          // Handle SMTP sending errors:
+          for (const email in response.message.error.emails) {
+            const errorMessage = response.message.error.emails[email];
+            tmp += '\n' + errorMessage;
+          }
+          return tmp;
+        } catch (error) {
+          return fallbackErrorMessage;
+        }
+      }
+
       var onError = function(data) {
         var response = data.xhr.responseJSON
         if (response && response.fields) {
@@ -76,7 +90,7 @@
               .text(response.fields[field])
           }
         } else {
-          const uiErrorMessage = data && data.message && typeof data.message  === "string" ? data.message : fallbackErrorMessage;
+          const uiErrorMessage = getErrorMessage(data);
           $FORM_ERROR
             .addClass('is-visible')
             .text(uiErrorMessage);

--- a/workspaces/default/themes/base/partials/auth/forms/register/oidc.html
+++ b/workspaces/default/themes/base/partials/auth/forms/register/oidc.html
@@ -76,9 +76,10 @@
               .text(response.fields[field])
           }
         } else {
+          const uiErrorMessage = data && data.message && typeof data.message  === "string" ? data.message : fallbackErrorMessage;
           $FORM_ERROR
             .addClass('is-visible')
-            .text(data.message || fallbackErrorMessage);
+            .text(uiErrorMessage);
         }
       }
 


### PR DESCRIPTION
I decided to try and verify that the error.message we receive is actually a string, otherwise to
just render the default error

So there are actually quite a few situations in which the API responds with an object as the error message, but only a few places we try to render that to the UI. In this instance, I think the better solution was to check the typing that comes back from the API and to render the default if there's anything other than a `string` in the `error.message`. I think we could refactor the API if we wanted to, but for this particular issue (TDX-1687), you'd have to change a bunch of endpoints on the API side.

Here's what it'll look like (devtool screenshot too)
![image](https://user-images.githubusercontent.com/2126677/146629262-7f6d81f8-efbf-49ab-83d2-badc3956eca5.png)
