### PR TITLE
css(site) add container max-widths and font-weight to match kongponents

### DIFF
--- a/workspaces/default/themes/base/assets/styles/site.css
+++ b/workspaces/default/themes/base/assets/styles/site.css
@@ -7,6 +7,35 @@ html {
   height: 100%;
   width: 100%;
   color: var(--primary_text, #000000);
+  font-weight: 300;
+}
+
+.container {
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .container {
+    max-width: 640px;
+  }
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 768px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .container {
+    max-width: 1024px;
+  }
+}
+
+@media (min-width: 1280px) {
+  .container {
+    max-width: 1280px;
+  }
 }
 
 /*****************************************


### PR DESCRIPTION
When the kongponents stylesheet comes in and overrides site styles there is a visual glitch where
the font-weight and container widths change dramatically between site.css and kongponents styles.

This adds the necessary styles to site.css to match the incoming kongponents styles.