### PR TITLE
css(site) add base font-weight to match kongponents

### DIFF
--- a/workspaces/default/themes/base/assets/styles/site.css
+++ b/workspaces/default/themes/base/assets/styles/site.css
@@ -7,6 +7,7 @@ html {
   height: 100%;
   width: 100%;
   color: var(--primary_text, #000000);
+  font-weight: 200;
 }
 
 /*****************************************


### PR DESCRIPTION
When the kongponents stylesheet comes in and overrides site styles there is a visual glitch where
the font-weight changes between site.css and kongponents styles. This sets the base font-weight in site.css to match kongponents.