### PR TITLE
feat(emails) add default email templates for application-related emails [TDX-2069]

### DIFF
--- a/workspaces/default/emails/application-service-approved.txt
+++ b/workspaces/default/emails/application-service-approved.txt
@@ -1,0 +1,13 @@
+---
+layout: emails/email_base.html
+
+subject: Developer Portal ({{portal.url}}) Application Request Approved
+heading: Hello {{email.developer_name}}!
+---
+We are emailing you to let you know that your request for application access from the
+Developer Portal account at <a href="{{portal.url}}">{{portal.url}}</a> has been approved.
+<p>
+  Application: {{email.application_name}}
+  <br>
+  Service: {{email.service_name}}
+</p>

--- a/workspaces/default/emails/application-service-approved.txt
+++ b/workspaces/default/emails/application-service-approved.txt
@@ -8,6 +8,4 @@ We are emailing you to let you know that your request for application access fro
 Developer Portal account at <a href="{{portal.url}}">{{portal.url}}</a> has been approved.
 <p>
   Application: {{email.application_name}}
-  <br>
-  Service: {{email.service_name}}
 </p>

--- a/workspaces/default/emails/application-service-pending.txt
+++ b/workspaces/default/emails/application-service-pending.txt
@@ -8,8 +8,6 @@ We are emailing you to let you know that your request for application access fro
 Developer Portal account at <a href="{{portal.url}}">{{portal.url}}</a> is pending.
 <p>
   Application: {{email.application_name}}
-  <br>
-  Service: {{email.service_name}}
 </p>
 <p>
   You will receive another email when your access has been approved.

--- a/workspaces/default/emails/application-service-pending.txt
+++ b/workspaces/default/emails/application-service-pending.txt
@@ -1,0 +1,16 @@
+---
+layout: emails/email_base.html
+
+subject: Developer Portal ({{portal.url}}) Application Request Pending
+heading: Hello {{email.developer_name}}!
+---
+We are emailing you to let you know that your request for application access from the
+Developer Portal account at <a href="{{portal.url}}">{{portal.url}}</a> is pending.
+<p>
+  Application: {{email.application_name}}
+  <br>
+  Service: {{email.service_name}}
+</p>
+<p>
+  You will receive another email when your access has been approved.
+</p>

--- a/workspaces/default/emails/application-service-rejected.txt
+++ b/workspaces/default/emails/application-service-rejected.txt
@@ -1,0 +1,13 @@
+---
+layout: emails/email_base.html
+
+subject: Developer Portal ({{portal.url}}) Application Request Denied
+heading: Hello {{email.developer_name}}
+---
+We are emailing you to let you know that your request for application access from the
+Developer Portal account at <a href="{{portal.url}}">{{portal.url}}</a> has been denied.
+<p>
+  Application: {{email.application_name}}
+  <br>
+  Service: {{email.service_name}}
+</p>

--- a/workspaces/default/emails/application-service-rejected.txt
+++ b/workspaces/default/emails/application-service-rejected.txt
@@ -8,6 +8,4 @@ We are emailing you to let you know that your request for application access fro
 Developer Portal account at <a href="{{portal.url}}">{{portal.url}}</a> has been denied.
 <p>
   Application: {{email.application_name}}
-  <br>
-  Service: {{email.service_name}}
 </p>

--- a/workspaces/default/emails/application-service-requested.txt
+++ b/workspaces/default/emails/application-service-requested.txt
@@ -13,8 +13,6 @@ heading: Hello Admin!
   Requested workspace: {{email.workspace}}
   <br>
   Requested application: {{email.application_name}}
-  <br>
-  Requested service: {{email.service_name}}
 </p>
 <p>
   Please visit <a href="{{email.admin_gui_url}}/applications/{{email.application_id}}#requested">

--- a/workspaces/default/emails/application-service-requested.txt
+++ b/workspaces/default/emails/application-service-requested.txt
@@ -16,7 +16,7 @@ heading: Hello Admin!
   Requested service: {{email.service_name}}
 </p>
 <p>
-  Please visit <a href="{{email.admin_gui_url}}/{{email.workspace}}/applications/{{email.application_id}}#requested">
-    {{email.admin_gui_url}}/{{email.workspace}}/applications/{{email.application_id}}#requested
+  Please visit <a href="{{email.admin_gui_url}}/applications/{{email.application_id}}#requested">
+    {{email.admin_gui_url}}/applications/{{email.application_id}}#requested
   </a> to review this request.
 </p>

--- a/workspaces/default/emails/application-service-requested.txt
+++ b/workspaces/default/emails/application-service-requested.txt
@@ -1,0 +1,22 @@
+---
+layout: emails/email_base.html
+
+title: Email
+
+subject: Request to access Developer Portal {{portal.url}} service from {{email.developer_email}}
+heading: Hello Admin!
+---
+{{email.developer_name}} ({{email.developer_email}}) has requested application access for {{portal.url}}.
+<br>
+<p>
+  Requested workspace: {{email.workspace}}
+  <br>
+  Requested application: {{email.application_name}}
+  <br>
+  Requested service: {{email.service_name}}
+</p>
+<p>
+  Please visit <a href="{{email.admin_gui_url}}/{{email.workspace}}/applications/{{email.application_id}}#requested">
+    {{email.admin_gui_url}}/{{email.workspace}}/applications/{{email.application_id}}#requested
+  </a> to review this request.
+</p>

--- a/workspaces/default/emails/application-service-requested.txt
+++ b/workspaces/default/emails/application-service-requested.txt
@@ -6,7 +6,8 @@ title: Email
 subject: Request to access Developer Portal {{portal.url}} service from {{email.developer_email}}
 heading: Hello Admin!
 ---
-{{email.developer_name}} ({{email.developer_email}}) has requested application access for {{portal.url}}.
+{{email.developer_name}} ({{email.developer_email}}) has requested application access for
+<a href="{{portal.url}}">{{portal.url}}</a>.
 <br>
 <p>
   Requested workspace: {{email.workspace}}

--- a/workspaces/default/emails/application-service-revoked.txt
+++ b/workspaces/default/emails/application-service-revoked.txt
@@ -4,10 +4,8 @@ layout: emails/email_base.html
 subject: Developer Portal ({{portal.url}}) Application Request Revoked
 heading: Hello {{email.developer_name}}
 ---
-We are emailing you to let you know that your request for application access from the
+We are emailing you to let you know that your application access from the
 Developer Portal account at <a href="{{portal.url}}">{{portal.url}}</a> has been revoked.
 <p>
   Application: {{email.application_name}}
-  <br>
-  Service: {{email.service_name}}
 </p>

--- a/workspaces/default/emails/application-service-revoked.txt
+++ b/workspaces/default/emails/application-service-revoked.txt
@@ -1,0 +1,13 @@
+---
+layout: emails/email_base.html
+
+subject: Developer Portal ({{portal.url}}) Application Request Revoked
+heading: Hello {{email.developer_name}}
+---
+We are emailing you to let you know that your request for application access from the
+Developer Portal account at <a href="{{portal.url}}">{{portal.url}}</a> has been revoked.
+<p>
+  Application: {{email.application_name}}
+  <br>
+  Service: {{email.service_name}}
+</p>


### PR DESCRIPTION
### Summary

Requesting access to a service in an application can now trigger emails to the developer and admins.

### Implementations

1. Adds email templates for sending to developers when the application status changes for the requested service:
  - application-service-approved.txt
  - application-service-pending.txt
  - application-service-rejected.txt
  - application-service-revoked.txt
2. Adds an email template for sending to admins when service access is requested for an application:
  - application-service-requested.txt


