### PR TITLE
feat(catalog): Implement configurable n-gram-based catalog search [TDX-2516]

### DIFF
--- a/workspaces/default/themes/base/assets/js/kong/kong.utils.js
+++ b/workspaces/default/themes/base/assets/js/kong/kong.utils.js
@@ -174,8 +174,8 @@ window.Kong.Utils.getStringSimilarity = function (a, b, nGram) {
     return res;
   }
 
-  var aPairs = getNGramPairs(a, nGram);
-  var bPairs = getNGramPairs(b, nGram);
+  var aPairs = getNGramPairs(a);
+  var bPairs = getNGramPairs(b);
 
   var matches = bPairs.filter(function (pair) {
     return aPairs.indexOf(pair) !== -1;

--- a/workspaces/default/themes/base/assets/js/kong/kong.utils.js
+++ b/workspaces/default/themes/base/assets/js/kong/kong.utils.js
@@ -66,7 +66,7 @@ window.Kong.Utils.getErrorMessage = function (response) {
 };
 
 /**
- * Get value of specified descendent property of an object or object array.
+ * Get value of specified nested property of an object or object array.
  *
  * The `key` argument accepts dot characters (`.`) to deeply traverse input objects
  * and asterisk characters (`*`) to select all properties of currently selected object.
@@ -94,13 +94,13 @@ window.Kong.Utils.getErrorMessage = function (response) {
  *
  *   `tags.*.name` key will get the values of the `name` property in all object properties inside the `tags` object.
  *
- * @param {Object|Object[]} objOrObjs - An object or array of objects to extract the values from
+ * @param {Object|Object[]} data - An object or array of objects to extract the values from
  * @param {string} key - Key to get the properties from given object(s)
  * @returns {string[]} Values of requested properties
  */
-window.Kong.Utils.getDescendantProperties = function (objOrObjs, key) {
-  if (!Array.isArray(objOrObjs)) {
-    objOrObjs = [objOrObjs];
+window.Kong.Utils.getNestedProperties = function (data, key) {
+  if (!Array.isArray(data)) {
+    data = [data];
   }
 
   var tree = key.split(".");
@@ -109,7 +109,7 @@ window.Kong.Utils.getDescendantProperties = function (objOrObjs, key) {
 
   if (currentKey === "*") {
     // Find all keys of given object if current key is *
-    newObjs = objOrObjs.reduce(function (acc, obj) {
+    newObjs = data.reduce(function (acc, obj) {
       Object.keys(obj).forEach(function (key) {
         acc.push(obj[key]);
       })
@@ -117,14 +117,14 @@ window.Kong.Utils.getDescendantProperties = function (objOrObjs, key) {
     }, []);
   } else {
     // Select the requested key from all input objects
-    newObjs = objOrObjs.map(function (obj) {
+    newObjs = data.map(function (obj) {
       return obj[currentKey];
     });
   }
 
   if (tree.length > 0) {
     // Recursively process nested objects
-    return window.Kong.Utils.getDescendantProperties(
+    return window.Kong.Utils.getNestedProperties(
       newObjs,
       tree.join("."),
     );
@@ -219,15 +219,15 @@ window.Kong.Utils.searchSimilar = function(items, phrase, options) {
 
       var weight = keyConfig.weight || 1;
 
-      window.Kong.Utils.getDescendantProperties(item, key).forEach(function (valueOrValues) {
+      window.Kong.Utils.getNestedProperties(item, key).forEach(function (data) {
         // The final selected property value can either have a string-like type or array of string-like types
-        if (!Array.isArray(valueOrValues)) {
-          valueOrValues = [valueOrValues];
+        if (!Array.isArray(data)) {
+          data = [data];
         }
 
         // Calculate score for all array items and get *only* the highest one.
         // This is a "one of" search
-        score += valueOrValues
+        score += data
           .map(function (value) {
             return window.Kong.Utils.getStringSimilarity((value || "").toString(), phrase, options.nGram) * weight;
           })

--- a/workspaces/default/themes/base/assets/js/kong/kong.utils.js
+++ b/workspaces/default/themes/base/assets/js/kong/kong.utils.js
@@ -64,3 +64,196 @@ window.Kong.Utils.getErrorMessage = function (response) {
     return fallbackErrorMessage;
   }
 };
+
+/**
+ * Get value of specified descendent property of an object or object array.
+ *
+ * The `key` argument accepts dot characters (`.`) to deeply traverse input objects
+ * and asterisk characters (`*`) to select all properties of currently selected object.
+ * You can use the asterisk character at any point of the object tree.
+ *
+ * Example:
+ *
+ *   For given input object:
+ *   ```
+ *   {
+ *     info: {
+ *       title: "Hello, World!",
+ *     },
+ *     tags: {
+ *       first: {
+ *         name: "First tag",
+ *       },
+ *       second: {
+ *         name: "Second tag",
+ *       },
+ *     },
+ *   }
+ *   ```
+ *   `info.title` key will get the value of the `title` property in the `info` object, and
+ *
+ *   `tags.*.name` key will get the values of the `name` property in all object properties inside the `tags` object.
+ *
+ * @param {Object|Object[]} objOrObjs - An object or array of objects to extract the values from
+ * @param {string} key - Key to get the properties from given object(s)
+ * @returns {string[]} Values of requested properties
+ */
+window.Kong.Utils.getDescendantProperties = function (objOrObjs, key) {
+  if (!Array.isArray(objOrObjs)) {
+    objOrObjs = [objOrObjs];
+  }
+
+  var tree = key.split(".");
+  var currentKey = tree.shift();
+  var newObjs;
+
+  if (currentKey === "*") {
+    // Find all keys of given object if current key is *
+    newObjs = objOrObjs.reduce(function (acc, obj) {
+      Object.keys(obj).forEach(function (key) {
+        acc.push(obj[key]);
+      })
+      return acc;
+    }, []);
+  } else {
+    // Select the requested key from all input objects
+    newObjs = objOrObjs.map(function (obj) {
+      return obj[currentKey];
+    });
+  }
+
+  if (tree.length > 0) {
+    // Recursively process nested objects
+    return window.Kong.Utils.getDescendantProperties(
+      newObjs,
+      tree.join("."),
+    );
+  }
+
+  return newObjs;
+}
+
+/**
+ * Get a numeric score of string similarity using n-grams
+ * @param {string} a - first string to compare
+ * @param {string} b - second string to compare
+ * @param {number} [nGram = 3] - integer gram size (defaults to 3)
+ * @returns {number} String similarity score from 0.0 to 1.0
+ */
+window.Kong.Utils.getStringSimilarity = function (a, b, nGram) {
+  if (!nGram) {
+    nGram = 3;
+  }
+
+  if (a.length === 0 || b.length === 0) {
+    return 0;
+  }
+
+  if (b.length > a.length) {
+    var temp = a
+    a = b
+    b = temp
+  }
+
+  function getNGramPairs (str) {
+    var padding = '';
+    for (var i = 0; i < nGram - 1; i++) {
+      padding += ' ';
+    }
+
+    str = padding + str.toLowerCase() + padding;
+
+    var res = [];
+    for (var i = 0; i < str.length - nGram + 1; i++) {
+      var s = str.substring(i, i + nGram)
+      if (res.indexOf(s) === -1) {
+        res.push(s);
+      }
+    }
+
+    return res;
+  }
+
+  var aPairs = getNGramPairs(a, nGram);
+  var bPairs = getNGramPairs(b, nGram);
+
+  var matches = bPairs.filter(function (pair) {
+    return aPairs.indexOf(pair) !== -1;
+  });
+
+  return matches.length / bPairs.length;
+}
+
+/**
+ * Search items within the input array similar to the given phrase.
+ * Compare one or many item property values by specifying the `options.keys` property.
+ *
+ * @param {Object[]} items - array of input objects to search in
+ * @param {string} phrase - phrase to search by
+ * @param {Object} options - options object
+ * @returns {Object[]} - filtered items array containing items matching given search criteria
+ */
+window.Kong.Utils.searchSimilar = function(items, phrase, options) {
+  if (phrase.length === 0) {
+    return items;
+  }
+
+  var threshold = options.threshold || 0.5;
+  var keys = options.keys || [];
+
+  // There's nothing to search by
+  if (keys.length === 0) {
+    return [];
+  }
+
+  // Get a score for given item.
+  // The higher the return number the more relevant the item is
+  function getItemSimilarity(item) {
+    var score = 0;
+
+    keys.forEach(function (keyConfig) {
+      var key = keyConfig.key;
+      if (!key) {
+        throw new Error("'key' property is required in search keys config");
+      }
+
+      var weight = keyConfig.weight || 1;
+
+      window.Kong.Utils.getDescendantProperties(item, key).forEach(function (valueOrValues) {
+        // The final selected property value can either have a string-like type or array of string-like types
+        if (!Array.isArray(valueOrValues)) {
+          valueOrValues = [valueOrValues];
+        }
+
+        // Calculate score for all array items and get *only* the highest one.
+        // This is a "one of" search
+        score += valueOrValues
+          .map(function (value) {
+            return window.Kong.Utils.getStringSimilarity((value || "").toString(), phrase, options.nGram) * weight;
+          })
+          .sort(function(a, b) {
+            if (a < b) return 1;
+            if (b > a) return -1;
+            return 0;
+          })
+          [0] || 0;
+      });
+    });
+
+    return score;
+  }
+
+  return items
+    .map(function (item) {
+      item.score = getItemSimilarity(item);
+      return item;
+    })
+    .filter(function (item) {
+      return item.score >= threshold;
+    })
+    .sort(function (a, b) {
+      if (a.score < b.score) return 1;
+      if (a.score > b.score) return -1;
+      return 0;
+    });
+}

--- a/workspaces/default/themes/base/partials/service-catalog/item.html
+++ b/workspaces/default/themes/base/partials/service-catalog/item.html
@@ -1,6 +1,6 @@
 <a
   href="{{string.sub(route, 2)}}"
-  data-tags="{% for _, tag in pairs(parsed.tags or {}) do %}{{tag.name:lower()}},{% end %}"
+  data-json="{{ json }}"
   class="catalog-item toggle-content is-visible">
   <div class="catalog-logo">
     {{parsed.info.title:sub(0,2)}}

--- a/workspaces/default/themes/base/partials/service-catalog/list.html
+++ b/workspaces/default/themes/base/partials/service-catalog/list.html
@@ -1,6 +1,10 @@
 <section class="catalog-list">
   {% if #specs > 0 then %}
     {% for _, spec in each(specs) do %}
+      {# You can expose any spec properties by adding them to the table below #}
+      {# If you want to enable frontend search on these fields, please update the updateSearchParams #}
+      {# function arguments in sidebar.html #}
+      {% spec.json = json_encode({ info = spec.parsed.info, tags = spec.parsed.tags or {} }) %}
       {(partials/service-catalog/item.html, spec)}
     {% end %}
   {% else %}

--- a/workspaces/default/themes/base/partials/service-catalog/sidebar.html
+++ b/workspaces/default/themes/base/partials/service-catalog/sidebar.html
@@ -56,15 +56,12 @@
     var filteredCatalogItems = catalogItems;
 
     function countCatalogItemsForTag (tag) {
-      var count = 0;
-
-      for (let item of catalogItems) {
+      return catalogItems.reduce(function(sum, item) {
         if (item.tags && item.tags.indexOf(tag) !== -1) {
-          count++;
+          sum += 1;
         }
-      }
-
-      return count;
+        return sum;
+      }, 0);
     }
 
     function updateCategoriesDOM() {

--- a/workspaces/default/themes/base/partials/service-catalog/sidebar.html
+++ b/workspaces/default/themes/base/partials/service-catalog/sidebar.html
@@ -15,147 +15,172 @@
 
 
 <script type="text/javascript">
-  window.addEventListener("load", function() {
+  window.addEventListener("load", function () {
     var $CATALOG_TAG_LINKS = $(".tag-link");
     var $CATALOG_ITEMS = $(".catalog-item");
-    var $CATALOG_FILTER = $(".catalog-filter");
+    var $CATALOG_FILTER_INPUT = $(".catalog-filter");
     var $CATALOG_LIST_NO_RESULTS = $(".catalog-list__no-results");
 
-    // returns hashmap where keys are tags and values are count of items
-    var generateTagList = function() {
-      var output = {};
-
-      $CATALOG_ITEMS.each(function(i, elem) {
-        var tags = elem.dataset.tags;
-        var value = 0;
-
-        value = elem.classList.contains("search-filtered") ? 0 : 1;
-
-        if (tags) {
-          tags = tags.split(",").filter(function(v) {
-            return v;
-          });
-
-          tags.forEach(function(tag) {
-            if (output[tag]) {
-              output[tag] += value;
-            } else {
-              output[tag] = value;
-            }
-          });
-        }
-      });
-
-      return output;
+    var searchParams = {
+      activeTag: null,
+      phrase: "",
     };
 
-    // update sidebar tag list counters, hide tags when empty
-    var updateCategories = function() {
-      var tags = generateTagList();
-      var activeTag = $CATALOG_TAG_LINKS.filter(".is-active");
-
-      Object.keys(tags).forEach(function(tag) {
-        var elem = $CATALOG_TAG_LINKS.filter('[data-tag="' + tag + '"]');
-        var count = tags[tag];
-        elem.find(".tag-link--count").text(count);
-
-        if (elem.hasClass('is-active') && count === 0) {
-          $CATALOG_LIST_NO_RESULTS.show();
-        }
+    var catalogItems = [];
+    $CATALOG_ITEMS.each(function (index, element) {
+      var data = $(element).data("json");
+      var tags = Object.keys(data.tags || {}).map(function (key) {
+        return data.tags[key].name.toLowerCase();
       });
-    };
 
-    var filterArrayByTagData = function(tag) {
-      return function(index, elem) {
-        return elem.dataset.tags.indexOf(tag) < 0;
+      catalogItems.push({
+        data: data,
+        tags: tags,
+        element: element,
+      });
+    });
+
+    var categories = {};
+    $CATALOG_TAG_LINKS.each(function (index, element) {
+      var tag = $(element).data("tag");
+      var countElement = $(element).find(".tag-link--count");
+
+      categories[tag] = {
+        tag: tag,
+        element: element,
+        countElement: countElement,
+        count: parseInt(countElement.text(), 10),
       };
-    };
+    });
 
-    var filterArrayByValue = function (value) {
-      return $CATALOG_ITEMS
-        .filter(":not(.tag-filtered)")
-        .filter(function(i, elem) {
-          return elem.innerText.toLowerCase().indexOf(value) < 0;
-        });
+    var filteredCatalogItems = catalogItems;
+
+    function countCatalogItemsForTag (tag) {
+      var count = 0;
+
+      for (let item of catalogItems) {
+        if (item.tags && item.tags.indexOf(tag) !== -1) {
+          count++;
+        }
+      }
+
+      return count;
     }
 
-    var filterCatalogListByTag = function(tag) {
-      $CATALOG_ITEMS
-        .filter(filterArrayByTagData(tag))
-        .toggleClass("tag-filtered");
+    function updateCategoriesDOM() {
+      Object.keys(categories).forEach(function (key) {
+        var category = categories[key];
 
-      $CATALOG_ITEMS
-        .filter(":not(.search-filtered)")
-        .filter(filterArrayByTagData(tag))
-        .toggleClass("is-visible");
-    };
+        $(category.countElement).text(countCatalogItemsForTag(category.tag));
 
-    var filterCatalogListByValue = function(value) {
-      var filteredItems = $CATALOG_ITEMS
-        .filter(function(i, elem) {
-          return elem.innerText.toLowerCase().indexOf(value) < 0;
-        });
+        if (category.tag === searchParams.activeTag) {
+          $(category.element).addClass("is-active");
+        } else {
+          $(category.element).removeClass("is-active");
+        }
+      })
+    }
 
-      if (filteredItems.length === $CATALOG_ITEMS.length) {
+    function updateItemsDOM() {
+      catalogItems.forEach(function (catalogItem) {
+        $(catalogItem.element).removeClass("is-visible");
+        $(catalogItem.element).css("order", "initial");
+      })
+
+      filteredCatalogItems.forEach(function (filteredItem, index) {
+        $(filteredItem.element).addClass("is-visible");
+        $(filteredItem.element).css("order", index + 1);
+      });
+
+      if (filteredCatalogItems.length === 0) {
         $CATALOG_LIST_NO_RESULTS.show();
       } else {
         $CATALOG_LIST_NO_RESULTS.hide();
       }
+    }
 
-      filteredItems.removeClass("is-visible").addClass("search-filtered");
-    };
+    function updateDOM() {
+      updateCategoriesDOM();
+      updateItemsDOM();
+    }
 
-    var clearTagFilters = function(event) {
-      $CATALOG_LIST_NO_RESULTS.hide();
-      $CATALOG_TAG_LINKS.removeClass("is-active");
+    function updateSearchParams(obj) {
+      if (obj.hasOwnProperty("activeTag")) {
+        searchParams.activeTag = obj.activeTag;
+      }
 
-      $CATALOG_ITEMS
-        .filter(":not(.is-visible,.search-filtered)")
-        .addClass("is-visible");
+      if (obj.hasOwnProperty("phrase")) {
+        searchParams.phrase = obj.phrase;
+      }
 
-      $CATALOG_ITEMS.removeClass("tag-filtered");
-    };
+      var items = catalogItems;
+      if (searchParams.activeTag) {
+        items = items.filter(function (item) {
+          return item.tags.indexOf(searchParams.activeTag) !== -1;
+        })
+      }
 
-    var clearSearchFilters = function(event) {
-      $CATALOG_LIST_NO_RESULTS.hide();
+      var phrase = searchParams.phrase;
+      // Start searching when phrase has at least 3 characters
+      if (phrase.length < 3) {
+        phrase = "";
+      }
 
-      $CATALOG_ITEMS
-        .filter(":not(.tag-filtered).search-filtered")
-        .addClass("is-visible");
+      // You can provide any keys to search specs by as long as they're included in the item's data-json attribute
+      // See service-catalog/item.html and Kong.Utils.searchSimilar docs for more details
+      filteredCatalogItems = Kong.Utils.searchSimilar(
+        items,
+        phrase,
+        {
+          keys: [
+            {
+              key: "data.info.title",
+              weight: 3,
+            },
+            {
+              key: "data.info.description",
+            },
+            {
+              key: "data.tags",
+              weight: 2,
+            },
+          ],
+          threshold: 1,
+        }
+      );
 
-      $CATALOG_ITEMS.removeClass("search-filtered");
-    };
+      updateDOM();
+    }
 
     var onClickCategory = function(event) {
       event.preventDefault();
 
       var target = $(this);
-      if (!target.hasClass("is-active")) {
-        clearTagFilters();
-      }
-      target.toggleClass("is-active");
+      var tag = target.data("tag");
 
-      filterCatalogListByTag(target.data("tag"));
-      updateCategories();
-      onInputFilter();
+      if (searchParams.activeTag === tag) {
+        // Unset the tag if it's active
+        updateSearchParams({
+          activeTag: null,
+        });
+      } else {
+        updateSearchParams({
+          activeTag: tag,
+        })
+      }
     };
 
     var onInputFilter = function() {
-      var value = $CATALOG_FILTER.val().toLowerCase();
+      var value = $CATALOG_FILTER_INPUT.val();
 
-      clearSearchFilters();
-
-      if (value) {
-        filterCatalogListByValue(value);
-        updateCategories();
-      } else {
-        updateCategories();
-      }
+      updateSearchParams({
+        phrase: value,
+      });
     };
 
     $(document).on("click", ".tag-link", onClickCategory);
 
-    $CATALOG_FILTER.on(
+    $CATALOG_FILTER_INPUT.on(
       "keydown",
       Kong.Utils.debounce(function() {
         onInputFilter();

--- a/workspaces/default/themes/base/partials/service-catalog/sidebar.html
+++ b/workspaces/default/themes/base/partials/service-catalog/sidebar.html
@@ -16,10 +16,10 @@
 
 <script type="text/javascript">
   window.addEventListener("load", function () {
-    var tagLinkElements = document.querySelectorAll('.tag-link');
-    var catalogItemElements = document.querySelectorAll('.catalog-item');
-    var filterInputElement = document.querySelector('.catalog-filter');
-    var noResultsElement = document.querySelector('.catalog-list__no-results');
+    var tagLinkElements = document.querySelectorAll(".tag-link");
+    var catalogItemElements = document.querySelectorAll(".catalog-item");
+    var filterInputElement = document.querySelector(".catalog-filter");
+    var noResultsElement = document.querySelector(".catalog-list__no-results");
 
     var searchParams = {
       activeTag: null,
@@ -27,7 +27,7 @@
     };
 
     var catalogItems = [];
-    catalogItemElements.forEach(function (element) {
+    Array.prototype.forEach.call(catalogItemElements, function (element) {
       var data = JSON.parse(element.dataset.json);
       var tags = Object.keys(data.tags || {}).map(function (key) {
         return data.tags[key].name.toLowerCase();
@@ -41,9 +41,9 @@
     });
 
     var categories = {};
-    tagLinkElements.forEach(function (element) {
+    Array.prototype.forEach.call(tagLinkElements, function (element) {
       var tag = element.dataset.tag;
-      var countElement = element.querySelector('.tag-link--count');
+      var countElement = element.querySelector(".tag-link--count");
 
       categories[tag] = {
         tag: tag,
@@ -52,7 +52,7 @@
         count: parseInt(countElement.innerText, 10),
       };
 
-      element.addEventListener('click', onClickCategory);
+      element.addEventListener("click", onClickCategory);
     });
 
     var filteredCatalogItems = catalogItems;
@@ -176,6 +176,6 @@
       });
     }
 
-    filterInputElement.addEventListener('keydown', Kong.Utils.debounce(onInputFilter, 80));
+    filterInputElement.addEventListener("keydown", Kong.Utils.debounce(onInputFilter, 80));
   });
 </script>

--- a/workspaces/default/themes/base/partials/service-catalog/sidebar.html
+++ b/workspaces/default/themes/base/partials/service-catalog/sidebar.html
@@ -16,10 +16,10 @@
 
 <script type="text/javascript">
   window.addEventListener("load", function () {
-    var $CATALOG_TAG_LINKS = $(".tag-link");
-    var $CATALOG_ITEMS = $(".catalog-item");
-    var $CATALOG_FILTER_INPUT = $(".catalog-filter");
-    var $CATALOG_LIST_NO_RESULTS = $(".catalog-list__no-results");
+    var tagLinkElements = document.querySelectorAll('.tag-link');
+    var catalogItemElements = document.querySelectorAll('.catalog-item');
+    var filterInputElement = document.querySelector('.catalog-filter');
+    var noResultsElement = document.querySelector('.catalog-list__no-results');
 
     var searchParams = {
       activeTag: null,
@@ -27,8 +27,8 @@
     };
 
     var catalogItems = [];
-    $CATALOG_ITEMS.each(function (index, element) {
-      var data = $(element).data("json");
+    catalogItemElements.forEach(function (element) {
+      var data = JSON.parse(element.dataset.json);
       var tags = Object.keys(data.tags || {}).map(function (key) {
         return data.tags[key].name.toLowerCase();
       });
@@ -41,16 +41,18 @@
     });
 
     var categories = {};
-    $CATALOG_TAG_LINKS.each(function (index, element) {
-      var tag = $(element).data("tag");
-      var countElement = $(element).find(".tag-link--count");
+    tagLinkElements.forEach(function (element) {
+      var tag = element.dataset.tag;
+      var countElement = element.querySelector('.tag-link--count');
 
       categories[tag] = {
         tag: tag,
         element: element,
         countElement: countElement,
-        count: parseInt(countElement.text(), 10),
+        count: parseInt(countElement.innerText, 10),
       };
+
+      element.addEventListener('click', onClickCategory);
     });
 
     var filteredCatalogItems = catalogItems;
@@ -59,31 +61,31 @@
       Object.keys(categories).forEach(function (key) {
         var category = categories[key];
 
-        $(category.countElement).text(category.count);
+        category.countElement.innerText = category.count;
 
         if (category.tag === searchParams.activeTag) {
-          $(category.element).addClass("is-active");
+          category.element.classList.add("is-active");
         } else {
-          $(category.element).removeClass("is-active");
+          category.element.classList.remove("is-active");
         }
       })
     }
 
     function updateItemsDOM() {
       catalogItems.forEach(function (catalogItem) {
-        $(catalogItem.element).removeClass("is-visible");
-        $(catalogItem.element).css("order", "initial");
+        catalogItem.element.classList.remove("is-visible");
+        catalogItem.element.style.order = "initial";
       })
 
       filteredCatalogItems.forEach(function (filteredItem, index) {
-        $(filteredItem.element).addClass("is-visible");
-        $(filteredItem.element).css("order", index + 1);
+        filteredItem.element.classList.add("is-visible");
+        filteredItem.element.style.order = index + 1;
       });
 
       if (filteredCatalogItems.length === 0) {
-        $CATALOG_LIST_NO_RESULTS.show();
+        noResultsElement.style.display = "block";
       } else {
-        $CATALOG_LIST_NO_RESULTS.hide();
+        noResultsElement.style.display = "none";
       }
     }
 
@@ -152,8 +154,7 @@
     function onClickCategory (event) {
       event.preventDefault();
 
-      var target = $(this);
-      var tag = target.data("tag");
+      var tag = event.target.dataset.tag;
 
       if (searchParams.activeTag === tag) {
         // Unset the tag if it's active
@@ -165,23 +166,16 @@
           activeTag: tag,
         })
       }
-    };
+    }
 
-    function onInputFilter () {
-      var value = $CATALOG_FILTER_INPUT.val();
+    function onInputFilter (event) {
+      var value = event.target.value;
 
       updateSearchParams({
         phrase: value,
       });
-    };
+    }
 
-    $(document).on("click", ".tag-link", onClickCategory);
-
-    $CATALOG_FILTER_INPUT.on(
-      "keydown",
-      Kong.Utils.debounce(function() {
-        onInputFilter();
-      }, 80)
-    );
+    filterInputElement.addEventListener('keydown', Kong.Utils.debounce(onInputFilter, 80));
   });
 </script>

--- a/workspaces/default/themes/base/partials/service-catalog/sidebar.html
+++ b/workspaces/default/themes/base/partials/service-catalog/sidebar.html
@@ -55,20 +55,11 @@
 
     var filteredCatalogItems = catalogItems;
 
-    function countCatalogItemsForTag (tag) {
-      return catalogItems.reduce(function(sum, item) {
-        if (item.tags && item.tags.indexOf(tag) !== -1) {
-          sum += 1;
-        }
-        return sum;
-      }, 0);
-    }
-
     function updateCategoriesDOM() {
       Object.keys(categories).forEach(function (key) {
         var category = categories[key];
 
-        $(category.countElement).text(countCatalogItemsForTag(category.tag));
+        $(category.countElement).text(category.count);
 
         if (category.tag === searchParams.activeTag) {
           $(category.element).addClass("is-active");
@@ -110,13 +101,6 @@
         searchParams.phrase = obj.phrase;
       }
 
-      var items = catalogItems;
-      if (searchParams.activeTag) {
-        items = items.filter(function (item) {
-          return item.tags.indexOf(searchParams.activeTag) !== -1;
-        })
-      }
-
       var phrase = searchParams.phrase;
       // Start searching when phrase has at least 3 characters
       if (phrase.length < 3) {
@@ -126,7 +110,7 @@
       // You can provide any keys to search specs by as long as they're included in the item's data-json attribute
       // See service-catalog/item.html and Kong.Utils.searchSimilar docs for more details
       filteredCatalogItems = Kong.Utils.searchSimilar(
-        items,
+        catalogItems,
         phrase,
         {
           keys: [
@@ -146,10 +130,26 @@
         }
       );
 
+      // Update category results count before filtering out catalog items by tag
+      Object.keys(categories).forEach(function (key) {
+        var category = categories[key];
+
+        category.count = filteredCatalogItems.filter(function (item) {
+          return item.tags.indexOf(category.tag) !== -1;
+        }).length;
+      });
+
+      // Filter out catalog items not having the selected tag
+      if (searchParams.activeTag) {
+        filteredCatalogItems = filteredCatalogItems.filter(function (item) {
+          return item.tags.indexOf(searchParams.activeTag) !== -1;
+        })
+      }
+
       updateDOM();
     }
 
-    var onClickCategory = function(event) {
+    function onClickCategory (event) {
       event.preventDefault();
 
       var target = $(this);
@@ -167,7 +167,7 @@
       }
     };
 
-    var onInputFilter = function() {
+    function onInputFilter () {
       var value = $CATALOG_FILTER_INPUT.val();
 
       updateSearchParams({


### PR DESCRIPTION
### Summary

This PR changes the implementation of the Service Catalog search functionality to provide a better user experience by using approximate string matching instead of exact string matching and allow developers to change how the search works. 

The search results can now be easily modified by changing `Kong.Utils.searchSimilar()` arguments in `partials/service-catalog/sidebar.html`. The new default configuration searches in specification title, description and tags. Weights of all keys are configurable and can be increased or decreased to adjust their importance. Additionally, the results are now sorted by score.

Default configuration:
```
{
  keys: [
    {
      key: "data.info.title",
      weight: 3,
    },
    {
      key: "data.info.description",
    },
    {
      key: "data.tags",
      weight: 2,
    },
  ],
  threshold: 1,
}
```
