### PR TITLE
fix: encode login credentials in UTF-8 form for non-ascii character compatibility

### DIFF
--- a/workspaces/default/themes/base/assets/js/kong/kong.auth.js
+++ b/workspaces/default/themes/base/assets/js/kong/kong.auth.js
@@ -18,7 +18,7 @@ window.Kong.Auth.BASIC_AUTH = {
   FIELDS: ['email', 'password'],
   getHeaders: function(fields) {
     return {
-      "Authorization": "Basic " + btoa(fields.email + ":" + fields.password)
+      "Authorization": "Basic " + btoa(unescape(encodeURIComponent(fields.email + ":" + fields.password)))
     }
   }
 }


### PR DESCRIPTION
### Summary

Currently we use default UCS-2 to encode login credentials in base64 form. But in signup form, the codec we are using is UTF-8, which result to a different byte sequence for non-ascii characters and cause login failure.

By changing the login form codec to UTF-8, this issue can be fixed and has no impact to any existing user.

Before start with KONG please read the CONTRIBUTING.md guidelines to learn where and on which 
channel you can search for the help and can ask genral question


### Implementations

1.
2.
3.
4.

### Changed Docs

1.
2.
3.
4.

### Issues Resolved

1.
2.
3.
4.




