### PR TITLE
fix(catalog-sidebar): fix the catalog sidebar filter click issue

### DIFF
--- a/workspaces/default/themes/base/partials/service-catalog/sidebar.html
+++ b/workspaces/default/themes/base/partials/service-catalog/sidebar.html
@@ -154,7 +154,7 @@
     function onClickCategory (event) {
       event.preventDefault();
 
-      var tag = event.target.dataset.tag;
+      var tag = event.currentTarget.dataset.tag;
 
       if (searchParams.activeTag === tag) {
         // Unset the tag if it's active


### PR DESCRIPTION
The category filter click handler now uses `event.target` to visit the element containing `data-tag` data.

The `event.target` can vary for the click event issued by some child elements, so we should use `event.currentTarget` instead.

This fix FTI-5377




