### PR TITLE
fix: correct relative path for font stylesheet assets loading

### DIFF
--- a/workspaces/default/themes/base/partials/theme/style.html
+++ b/workspaces/default/themes/base/partials/theme/style.html
@@ -1,13 +1,13 @@
 <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
 
 {% if theme.font("base") then %}
-  <link href="../../assets/fonts/{{theme.font('base')}}.css" rel="stylesheet">
+  <link href="assets/fonts/{{theme.font('base')}}.css" rel="stylesheet">
 {% end %}
 {% if theme.font("code") ~= theme.font("base") then %}
-  <link href="../../assets/fonts/{{theme.font('code')}}.css" rel="stylesheet">
+  <link href="assets/fonts/{{theme.font('code')}}.css" rel="stylesheet">
 {% end %}
 {% if theme.font("headings") ~= theme.font("base") then %}
-  <link href="../../assets/fonts/{{theme.font('headings')}}.css" rel="stylesheet">
+  <link href="assets/fonts/{{theme.font('headings')}}.css" rel="stylesheet">
 {% end %}
 
 <style>


### PR DESCRIPTION
this change forces loading font stylesheet under the workspace namespace

fix FTI-5623, assets will not be available if the default workspace is not enabled