### PR TITLE
fix: disable telephone format detection for the whole site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/workspaces/default/themes/base/partials/theme/head.html
+++ b/workspaces/default/themes/base/partials/theme/head.html
@@ -5,6 +5,7 @@
     <base href="{*portal.url*}/" />
     {(partials/theme/style.html)}
     <meta charset="UTF-8">
+    <meta name="format-detection" content="telephone=no">
     <link href="assets/styles/normalize.min.css" rel="stylesheet" />
     <link href="assets/styles/framework.min.css" rel="stylesheet" />
     <link href="assets/styles/site.css" rel="stylesheet" />


### PR DESCRIPTION
This fix FTI-5739 as Safari on iOS tries to interpret number string as phone number

This PR also changes `timeout-minutes` back to 20 minutes since the default value (10 minutes) is too short for a typical CI run


### Summary

SUMMARY_GOES_HERE
<!---- Please write summery as elaborative as you can it will help the contributors ---->

### Implementations

1.
2.
3.
4.

### Changed Docs

1.
2.
3.
4.

### Issues Resolved

1.
2.
3.
4.




